### PR TITLE
create/resolve/update DIDs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,8 @@ pipeline {
     environment {
         APP_NAME = "panacea-core"
         GIT_COMMIT_HASH = sh (script: "git log -n 1 --pretty=format:'%H'", returnStdout: true)
-		IMAGE_NAME = "${APP_NAME}:${GIT_COMMIT_HASH}"
-		IMAGE_NAME_BUILD_ENV= "${IMAGE_NAME}-build-env"
+	    IMAGE_NAME = "${APP_NAME}:${GIT_COMMIT_HASH}"
+	    IMAGE_NAME_BUILD_ENV= "${IMAGE_NAME}-build-env"
     }
 
     stages {

--- a/app/export.go
+++ b/app/export.go
@@ -2,8 +2,9 @@ package app
 
 import (
 	"encoding/json"
-	"github.com/medibloc/panacea-core/x/aol"
 	"log"
+
+	"github.com/medibloc/panacea-core/x/aol"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmtypes "github.com/tendermint/tendermint/types"
@@ -51,6 +52,7 @@ func (app *PanaceaApp) ExportAppStateAndValidators(forZeroHeight bool, jailWhite
 		crisis.ExportGenesis(ctx, app.crisisKeeper),
 		slashing.ExportGenesis(ctx, app.slashingKeeper),
 		aol.ExportGenesis(ctx, app.aolKeeper),
+		// did.ExportGenesis(ctx, app.didKeeper), // TODO
 	)
 	appState, err = codec.MarshalJSONIndent(app.cdc, genState)
 	if err != nil {

--- a/cmd/panaceacli/main.go
+++ b/cmd/panaceacli/main.go
@@ -38,6 +38,7 @@ import (
 	staking "github.com/cosmos/cosmos-sdk/x/staking/client/rest"
 	aol "github.com/medibloc/panacea-core/x/aol"
 	aolrest "github.com/medibloc/panacea-core/x/aol/client/rest"
+	did "github.com/medibloc/panacea-core/x/did"
 
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	bankcmd "github.com/cosmos/cosmos-sdk/x/bank/client/cli"
@@ -49,6 +50,7 @@ import (
 	slashingclient "github.com/cosmos/cosmos-sdk/x/slashing/client"
 	stakingclient "github.com/cosmos/cosmos-sdk/x/staking/client"
 	aolClient "github.com/medibloc/panacea-core/x/aol/client"
+	didClient "github.com/medibloc/panacea-core/x/did/client"
 
 	_ "github.com/medibloc/panacea-core/client/lcd/statik"
 )
@@ -83,6 +85,7 @@ func main() {
 		slashingclient.NewModuleClient(sl.StoreKey, cdc),
 		crisisclient.NewModuleClient(sl.StoreKey, cdc),
 		aolClient.NewModuleClient(aol.StoreKey, cdc),
+		didClient.NewModuleClient(did.StoreKey, cdc),
 	}
 
 	rootCmd := &cobra.Command{
@@ -186,6 +189,7 @@ func registerRoutes(rs *lcd.RestServer) {
 	gov.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc)
 	mintrest.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc)
 	aolrest.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, aol.StoreKey)
+	//TODO: didrest.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, did.StoreKey)
 }
 
 func registerSwaggerUI(rs *lcd.RestServer) {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace golang.org/x/crypto => github.com/tendermint/crypto v0.0.0-2018082004570
 
 require (
 	github.com/bombsimon/wsl v1.2.1 // indirect
+	github.com/btcsuite/btcutil v1.0.2
 	github.com/cosmos/cosmos-sdk v0.34.7
 	github.com/golangci/golangci-lint v1.22.2 // indirect
 	github.com/gorilla/mux v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -25,9 +25,14 @@ github.com/bombsimon/wsl/v2 v2.0.0 h1:+Vjcn+/T5lSrO8Bjzhk4v14Un/2UyCA1E3V5j9nwTk
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d h1:xG8Pj6Y6J760xwETNmMzmlt38QSwz0BLp1cZ09g27uw=
 github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d/go.mod h1:d3C0AkH6BRcvO8T0UEPu53cnw4IbV63x1bEjildYhO0=
+github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
+github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20180706230648-ab6388e0c60a h1:RQMUrEILyYJEoAT34XS/kLu40vC0+po/UfxrBBA4qZE=
 github.com/btcsuite/btcutil v0.0.0-20180706230648-ab6388e0c60a/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
+github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=

--- a/x/did/alias.go
+++ b/x/did/alias.go
@@ -1,0 +1,19 @@
+package did
+
+import "github.com/medibloc/panacea-core/x/did/types"
+
+const (
+	ModuleName   = types.ModuleName
+	StoreKey     = types.StoreKey
+	RouterKey    = types.RouterKey
+	QuerierRoute = types.QuerierRoute
+)
+
+var (
+	RegisterCodec = types.RegisterCodec
+)
+
+type (
+	MsgCreateDID = types.MsgCreateDID
+	MsgUpdateDID = types.MsgUpdateDID
+)

--- a/x/did/client/cli/query.go
+++ b/x/did/client/cli/query.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"errors"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/medibloc/panacea-core/x/did"
+	"github.com/medibloc/panacea-core/x/did/types"
+	"github.com/spf13/cobra"
+)
+
+const (
+	RouteResolveDID = "custom/did/resolveDid"
+)
+
+func GetCmdResolveDID(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resolve-did [did]",
+		Short: "Resolve a DID",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			id := types.DID(args[0])
+			if !id.IsValid() {
+				return types.ErrInvalidDID(id)
+			}
+
+			params := did.ResolveDIDParams{id}
+			bz, err := cdc.MarshalJSON(params)
+			if err != nil {
+				return err
+			}
+
+			res, err := cliCtx.QueryWithData(RouteResolveDID, bz)
+			if err != nil {
+				return err
+			}
+
+			var doc types.DIDDocument
+			cdc.MustUnmarshalJSON(res, &doc)
+			if doc.IsEmpty() {
+				return errors.New("DID not found")
+			}
+			return cliCtx.PrintOutput(doc)
+		},
+	}
+	return cmd
+}

--- a/x/did/client/cli/query.go
+++ b/x/did/client/cli/query.go
@@ -22,7 +22,7 @@ func GetCmdResolveDID(cdc *codec.Codec) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			id := types.DID(args[0])
-			if !id.IsValid() {
+			if !id.Valid() {
 				return types.ErrInvalidDID(id)
 			}
 
@@ -39,7 +39,7 @@ func GetCmdResolveDID(cdc *codec.Codec) *cobra.Command {
 
 			var doc types.DIDDocument
 			cdc.MustUnmarshalJSON(res, &doc)
-			if doc.IsEmpty() {
+			if doc.Empty() {
 				return errors.New("DID not found")
 			}
 			return cliCtx.PrintOutput(doc)

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/utils"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
+	"github.com/medibloc/panacea-core/x/did/types"
+	"github.com/spf13/cobra"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+)
+
+func GetCmdCreateDID(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create-did",
+		Short: "Create a DID",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
+
+			privKey := secp256k1.GenPrivKey()      //TODO: implement wallet
+			fmt.Println(base58.Encode(privKey[:])) //TODO: don't print it. store it securely.
+			pubKey := privKey.PubKey()
+
+			did := types.NewDID(pubKey, types.ES256K)
+			doc := types.NewDIDDocument(
+				did,
+				types.MustNewPubKey("key1", pubKey, types.ES256K),
+			)
+
+			msg := types.NewMsgCreateDID(did, doc, cliCtx.GetFromAddress())
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg}, false)
+		},
+	}
+	return cmd
+}
+
+func GetCmdUpdateDID(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-did [did] [priv-key-base58] [pub-key-id] [did-doc]",
+		Short: "Update a DID Document",
+		Args:  cobra.ExactArgs(4),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
+
+			did := types.DID(args[0])
+			if !did.IsValid() {
+				return types.ErrInvalidDID(did)
+			}
+
+			// private key which is corresponding to the public key registered in the DID document
+			// TODO: Don't get this via CLI arg. Implement Wallet.
+			privKey, err := types.NewPrivKeyFromBase58(args[1])
+			if err != nil {
+				return types.ErrInvalidSecp256k1PrivateKey(err)
+			}
+			pubKeyID := types.PubKeyID(args[2])
+
+			// TODO: Get a new DID doc via stdin or file. I tried it, but it didn't work because cosmos-sdk also tries to
+			// read a passphrase from stdin.
+			var doc types.DIDDocument
+			err = json.Unmarshal([]byte(args[3]), &doc)
+			if err != nil || !doc.IsValid() {
+				return types.ErrInvalidDIDDocument()
+			}
+
+			// For proving that I know the private key
+			sig, err := privKey.Sign(doc.GetSignBytes())
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgUpdateDID(did, doc, pubKeyID, sig, cliCtx.GetFromAddress())
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg}, false)
+		},
+	}
+	return cmd
+}

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -29,10 +29,7 @@ func GetCmdCreateDID(cdc *codec.Codec) *cobra.Command {
 			pubKey := privKey.PubKey()
 
 			did := types.NewDID(pubKey, types.ES256K)
-			doc := types.NewDIDDocument(
-				did,
-				types.MustNewPubKey("key1", pubKey, types.ES256K),
-			)
+			doc := types.NewDIDDocument(did, types.NewPubKey("key1", pubKey, types.ES256K))
 
 			msg := types.NewMsgCreateDID(did, doc, cliCtx.GetFromAddress())
 			if err := msg.ValidateBasic(); err != nil {

--- a/x/did/client/module_client.go
+++ b/x/did/client/module_client.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/medibloc/panacea-core/x/did/types"
+	"github.com/spf13/cobra"
+	"github.com/tendermint/go-amino"
+
+	didCmds "github.com/medibloc/panacea-core/x/did/client/cli"
+)
+
+// ModuleClient exports all client functionalities from this module
+type ModuleClient struct {
+	storeKey string
+	cdc      *amino.Codec
+}
+
+func NewModuleClient(storeKey string, cdc *amino.Codec) ModuleClient {
+	return ModuleClient{storeKey, cdc}
+}
+
+// GetQueryCmd returns the cli query commands for this module
+func (mc ModuleClient) GetQueryCmd() *cobra.Command {
+	didQueryCmd := &cobra.Command{
+		Use:   types.ModuleName,
+		Short: "Querying commands for the did module",
+	}
+
+	didQueryCmd.AddCommand(client.GetCommands(
+		didCmds.GetCmdResolveDID(mc.cdc),
+	)...)
+
+	return didQueryCmd
+}
+
+// GetTxCmd returns the transaction commands for this module
+func (mc ModuleClient) GetTxCmd() *cobra.Command {
+	didTxCmd := &cobra.Command{
+		Use:   types.ModuleName,
+		Short: "did transaction subcommands",
+	}
+
+	didTxCmd.AddCommand(client.PostCommands(
+		didCmds.GetCmdCreateDID(mc.cdc),
+		didCmds.GetCmdUpdateDID(mc.cdc),
+	)...)
+
+	return didTxCmd
+}

--- a/x/did/handler.go
+++ b/x/did/handler.go
@@ -33,7 +33,7 @@ func handleMsgCreateDID(ctx sdk.Context, keeper Keeper, msg MsgCreateDID) sdk.Re
 
 func handleMsgUpdateDID(ctx sdk.Context, keeper Keeper, msg MsgUpdateDID) sdk.Result {
 	curDoc := keeper.GetDID(ctx, msg.DID)
-	if curDoc.IsEmpty() {
+	if curDoc.Empty() {
 		return types.ErrDIDNotFound(msg.DID).Result()
 	}
 
@@ -44,7 +44,7 @@ func handleMsgUpdateDID(ctx sdk.Context, keeper Keeper, msg MsgUpdateDID) sdk.Re
 
 	pubKeySecp256k1, err := types.NewPubKeyFromBase58(pubKey.KeyBase58)
 	if err != nil {
-		return types.ErrInvalidSecp256k1PrivateKey(err).Result()
+		return types.ErrInvalidSecp256k1PublicKey(err).Result()
 	}
 	if !pubKeySecp256k1.VerifyBytes(msg.Document.GetSignBytes(), msg.Signature) {
 		return types.ErrSigVerificationFailed().Result()

--- a/x/did/handler.go
+++ b/x/did/handler.go
@@ -1,0 +1,55 @@
+package did
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/medibloc/panacea-core/x/did/types"
+)
+
+// NewHandler returns a handler for "did" type messages
+func NewHandler(keeper Keeper) sdk.Handler {
+	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+		switch msg := msg.(type) {
+		case MsgCreateDID:
+			return handleMsgCreateDID(ctx, keeper, msg)
+		case MsgUpdateDID:
+			return handleMsgUpdateDID(ctx, keeper, msg)
+		default:
+			errMsg := fmt.Sprintf("Unrecognized did Msg type: %v", msg.Type())
+			return sdk.ErrUnknownRequest(errMsg).Result()
+		}
+	}
+}
+
+func handleMsgCreateDID(ctx sdk.Context, keeper Keeper, msg MsgCreateDID) sdk.Result {
+	if keeper.HasDID(ctx, msg.DID) {
+		return types.ErrDIDExists(msg.DID).Result()
+	}
+
+	keeper.SetDID(ctx, msg.DID, msg.Document)
+	return sdk.Result{}
+}
+
+func handleMsgUpdateDID(ctx sdk.Context, keeper Keeper, msg MsgUpdateDID) sdk.Result {
+	curDoc := keeper.GetDID(ctx, msg.DID)
+	if curDoc.IsEmpty() {
+		return types.ErrDIDNotFound(msg.DID).Result()
+	}
+
+	pubKey, ok := curDoc.PubKeyByID(msg.SigPubKeyID)
+	if !ok {
+		return types.ErrPubKeyIDNotFound(msg.SigPubKeyID).Result()
+	}
+
+	pubKeySecp256k1, err := types.NewPubKeyFromBase58(pubKey.KeyBase58)
+	if err != nil {
+		return types.ErrInvalidSecp256k1PrivateKey(err).Result()
+	}
+	if !pubKeySecp256k1.VerifyBytes(msg.Document.GetSignBytes(), msg.Signature) {
+		return types.ErrSigVerificationFailed().Result()
+	}
+
+	keeper.SetDID(ctx, msg.DID, msg.Document)
+	return sdk.Result{}
+}

--- a/x/did/keeper.go
+++ b/x/did/keeper.go
@@ -1,0 +1,50 @@
+package did
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/medibloc/panacea-core/x/did/types"
+)
+
+// Keeper maintains the link to data storage
+// and exposes getter/setter methods for
+// the various parts of the state machine
+type Keeper struct {
+	// Unexposed key to access store from sdk.Context
+	storeKey sdk.StoreKey
+
+	cdc *codec.Codec
+}
+
+// NewKeeper creates a new instance of the did Keeper
+func NewKeeper(storeKey sdk.StoreKey, cdc *codec.Codec) Keeper {
+	return Keeper{
+		storeKey: storeKey,
+		cdc:      cdc,
+	}
+}
+
+func (k Keeper) SetDID(ctx sdk.Context, did types.DID, doc types.DIDDocument) {
+	store := ctx.KVStore(k.storeKey)
+	key := DIDKey(did)
+	bz := k.cdc.MustMarshalBinaryLengthPrefixed(doc)
+	store.Set(key, bz)
+}
+
+func (k Keeper) HasDID(ctx sdk.Context, did types.DID) bool {
+	store := ctx.KVStore(k.storeKey)
+	return store.Has(DIDKey(did))
+}
+
+func (k Keeper) GetDID(ctx sdk.Context, did types.DID) types.DIDDocument {
+	store := ctx.KVStore(k.storeKey)
+	key := DIDKey(did)
+	bz := store.Get(key)
+	if bz == nil {
+		return types.DIDDocument{}
+	}
+
+	var doc types.DIDDocument
+	k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &doc)
+	return doc
+}

--- a/x/did/keeper_keys.go
+++ b/x/did/keeper_keys.go
@@ -1,0 +1,20 @@
+package did
+
+import (
+	"bytes"
+
+	"github.com/medibloc/panacea-core/x/did/types"
+)
+
+var (
+	KeyDelimiter = []byte{0x00}
+
+	DIDKeyPrefix = []byte{0x11} // {Prefix}{DID}
+)
+
+func DIDKey(did types.DID) []byte {
+	return bytes.Join([][]byte{
+		DIDKeyPrefix,
+		[]byte(did),
+	}, KeyDelimiter)
+}

--- a/x/did/querier.go
+++ b/x/did/querier.go
@@ -1,0 +1,42 @@
+package did
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/medibloc/panacea-core/x/did/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+const (
+	QueryResolveDID = "resolveDid"
+)
+
+// NewQuerier is the module level router for state queries
+func NewQuerier(keeper Keeper) sdk.Querier {
+	return func(ctx sdk.Context, path []string, req abci.RequestQuery) ([]byte, sdk.Error) {
+		switch path[0] {
+		case QueryResolveDID:
+			return resolveDID(ctx, path[1:], req, keeper)
+		default:
+			return nil, sdk.ErrUnknownRequest("unknown did query endpoint")
+		}
+	}
+}
+
+type ResolveDIDParams struct {
+	DID types.DID
+}
+
+func resolveDID(ctx sdk.Context, path []string, req abci.RequestQuery, k Keeper) ([]byte, sdk.Error) {
+	var params ResolveDIDParams
+	err := k.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
+		return nil, sdk.ErrUnknownRequest(sdk.AppendMsgToErr("incorrectly formated request data", err.Error()))
+	}
+
+	bz, err := codec.MarshalJSONIndent(k.cdc, k.GetDID(ctx, params.DID))
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
+	}
+	return bz, nil
+}

--- a/x/did/types/codec.go
+++ b/x/did/types/codec.go
@@ -1,0 +1,17 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+)
+
+var didCodec = codec.New()
+
+func init() {
+	RegisterCodec(didCodec)
+}
+
+// RegisterCodec registers concrete types on Amino codec
+func RegisterCodec(cdc *codec.Codec) {
+	cdc.RegisterConcrete(MsgCreateDID{}, "did/MsgCreateDID", nil)
+	cdc.RegisterConcrete(MsgUpdateDID{}, "did/MsgUpdateDID", nil)
+}

--- a/x/did/types/did.go
+++ b/x/did/types/did.go
@@ -1,0 +1,200 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/btcsuite/btcutil/base58"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+)
+
+type DID string
+
+const (
+	DIDMethod     = "panacea"
+	Base58Charset = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+)
+
+func NewDID(pubKey crypto.PubKey, keyType PubKeyType) DID {
+	networkID := "testnet" // TODO: get this from somewhere
+	idStr := mustPubKeyBase58(pubKey, keyType, 16)
+	return DID(fmt.Sprintf("did:%s:%s:%s", DIDMethod, networkID, idStr))
+}
+
+func (did DID) IsValid() bool {
+	pattern := fmt.Sprintf("^did:panacea:(mainnet|testnet):[%s]{21,22}$", Base58Charset)
+	match, _ := regexp.MatchString(pattern, string(did))
+	return match
+}
+
+func (did DID) IsEmpty() bool {
+	return did == ""
+}
+
+type DIDDocument struct {
+	ID              DID              `json:"id"`
+	PubKeys         []PubKey         `json:"publicKey"`
+	Authentications []Authentication `json:"authentication"`
+}
+
+func NewDIDDocument(id DID, pubKey PubKey) DIDDocument {
+	return DIDDocument{
+		ID:              id,
+		PubKeys:         []PubKey{pubKey},
+		Authentications: []Authentication{Authentication(pubKey.ID)},
+	}
+}
+
+func (doc DIDDocument) IsValid() bool {
+	if !doc.ID.IsValid() || doc.PubKeys == nil || doc.Authentications == nil {
+		return false
+	}
+
+	for _, pubKey := range doc.PubKeys {
+		if !pubKey.IsValid() {
+			return false
+		}
+	}
+
+	for _, auth := range doc.Authentications {
+		if !auth.IsValid() {
+			return false
+		}
+		if _, ok := doc.PubKeyByID(PubKeyID(auth)); !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (doc DIDDocument) IsEmpty() bool {
+	return doc.ID.IsEmpty()
+}
+
+func (doc DIDDocument) String() string {
+	bz, _ := json.Marshal(doc)
+	return string(bz)
+}
+
+// GetSignBytes returns a byte array which is used to generate a signature for verifying DID ownership.
+func (doc DIDDocument) GetSignBytes() []byte {
+	return sdk.MustSortJSON(didCodec.MustMarshalJSON(doc))
+}
+
+// PubKeyByID finds a PubKey by ID.
+// If the corresponding PubKey doesn't exist, it returns a false.
+func (doc DIDDocument) PubKeyByID(id PubKeyID) (*PubKey, bool) {
+	for i := 0; i < len(doc.PubKeys); i++ {
+		pubKey := &doc.PubKeys[i]
+		if pubKey.ID == id {
+			return pubKey, true
+		}
+	}
+	return nil, false
+}
+
+type PubKey struct {
+	ID        PubKeyID   `json:"id"`
+	Type      PubKeyType `json:"type"`
+	KeyBase58 string     `json:"publicKeyBase58"`
+}
+
+type PubKeyID string
+
+func MustNewPubKey(id PubKeyID, key crypto.PubKey, keyType PubKeyType) PubKey {
+	if id == "" {
+		panic("id shouldn't be empty")
+	}
+	if key == nil {
+		panic("key shouldn't be empty")
+	}
+	if !keyType.IsValid() {
+		panic("keyType is invalid")
+	}
+
+	return PubKey{
+		ID:        id,
+		Type:      keyType,
+		KeyBase58: mustPubKeyBase58(key, keyType, 0),
+	}
+}
+
+func mustPubKeyBase58(key crypto.PubKey, keyType PubKeyType, truncateLen int) string {
+	switch keyType {
+	case ES256K:
+		return encodePubKeyES256K(key, truncateLen)
+	}
+	panic(fmt.Sprintf("unsupported pubkey type: %v", keyType))
+}
+
+func encodePubKeyES256K(key crypto.PubKey, truncateLen int) string {
+	keyES256K := key.(secp256k1.PubKeySecp256k1)
+
+	var k []byte
+	if truncateLen > 0 {
+		k = keyES256K[:truncateLen]
+	} else {
+		k = keyES256K[:]
+	}
+
+	return base58.Encode(k)
+}
+
+func (pk PubKey) IsValid() bool {
+	if pk.ID == "" || pk.Type.IsValid() {
+		return false
+	}
+
+	pattern := fmt.Sprintf("^[%s]$", Base58Charset)
+	matched, _ := regexp.MatchString(pattern, pk.KeyBase58)
+	return matched
+}
+
+type PubKeyType string
+
+const (
+	ES256K PubKeyType = "Secp256k1VerificationKey2018"
+)
+
+func (t PubKeyType) IsValid() bool {
+	switch t {
+	case ES256K:
+		return true
+	}
+	return false
+}
+
+// TODO: to be extended
+type Authentication PubKeyID
+
+func (a Authentication) IsValid() bool {
+	return a != ""
+}
+
+// NewPrivKeyFromBase58 decodes a base58-encoded Secp256k1 private key.
+// It returns an error when the length of the input is invalid.
+func NewPrivKeyFromBase58(b58 string) (secp256k1.PrivKeySecp256k1, error) {
+	var key secp256k1.PrivKeySecp256k1
+	decoded := base58.Decode(b58)
+	if len(decoded) != len(key) {
+		return key, fmt.Errorf("invalid Secp256k1 private key. len:%d, expected:%d", len(decoded), len(key))
+	}
+	copy(key[:], decoded)
+	return key, nil
+}
+
+// NewPubKeyFromBase58 decodes a base58-encoded Secp256k1 public key.
+// It returns an error when the length of the input is invalid.
+func NewPubKeyFromBase58(b58 string) (secp256k1.PubKeySecp256k1, error) {
+	var key secp256k1.PubKeySecp256k1
+	decoded := base58.Decode(b58)
+	if len(decoded) != len(key) {
+		return key, fmt.Errorf("invalid Secp256k1 public key. len:%d, expected:%d", len(decoded), len(key))
+	}
+	copy(key[:], decoded)
+	return key, nil
+}

--- a/x/did/types/did.go
+++ b/x/did/types/did.go
@@ -145,11 +145,11 @@ func encodePubKeyES256K(key crypto.PubKey, truncateLen int) string {
 }
 
 func (pk PubKey) IsValid() bool {
-	if pk.ID == "" || pk.Type.IsValid() {
+	if pk.ID == "" || !pk.Type.IsValid() {
 		return false
 	}
 
-	pattern := fmt.Sprintf("^[%s]$", Base58Charset)
+	pattern := fmt.Sprintf("^[%s]+$", Base58Charset)
 	matched, _ := regexp.MatchString(pattern, pk.KeyBase58)
 	return matched
 }

--- a/x/did/types/did.go
+++ b/x/did/types/did.go
@@ -20,7 +20,7 @@ const (
 
 func NewDID(pubKey crypto.PubKey, keyType PubKeyType) DID {
 	networkID := "testnet" // TODO: get this from somewhere
-	idStr := mustPubKeyBase58(pubKey, keyType, 16)
+	idStr := newPubKeyBase58(pubKey, keyType, 16)
 	return DID(fmt.Sprintf("did:%s:%s:%s", DIDMethod, networkID, idStr))
 }
 
@@ -105,25 +105,15 @@ type PubKey struct {
 
 type PubKeyID string
 
-func MustNewPubKey(id PubKeyID, key crypto.PubKey, keyType PubKeyType) PubKey {
-	if id == "" {
-		panic("id shouldn't be empty")
-	}
-	if key == nil {
-		panic("key shouldn't be empty")
-	}
-	if !keyType.IsValid() {
-		panic("keyType is invalid")
-	}
-
+func NewPubKey(id PubKeyID, key crypto.PubKey, keyType PubKeyType) PubKey {
 	return PubKey{
 		ID:        id,
 		Type:      keyType,
-		KeyBase58: mustPubKeyBase58(key, keyType, 0),
+		KeyBase58: newPubKeyBase58(key, keyType, 0),
 	}
 }
 
-func mustPubKeyBase58(key crypto.PubKey, keyType PubKeyType, truncateLen int) string {
+func newPubKeyBase58(key crypto.PubKey, keyType PubKeyType, truncateLen int) string {
 	switch keyType {
 	case ES256K:
 		return encodePubKeyES256K(key, truncateLen)

--- a/x/did/types/errors.go
+++ b/x/did/types/errors.go
@@ -1,0 +1,55 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const DefaultCodespace sdk.CodespaceType = ModuleName
+
+const (
+	CodeDIDExists                  sdk.CodeType = 101
+	CodeInvalidDID                 sdk.CodeType = 102
+	CodeInvalidDIDDocument         sdk.CodeType = 103
+	CodeDIDNotFound                sdk.CodeType = 104
+	CodeInvalidSignature           sdk.CodeType = 105
+	CodePubKeyIDNotFound           sdk.CodeType = 106
+	CodeSigVerificationFailed      sdk.CodeType = 107
+	CodeInvalidSecp256k1PrivateKey sdk.CodeType = 108
+	CodeInvalidSecp256k1PublicKey  sdk.CodeType = 109
+)
+
+func ErrDIDExists(did DID) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeDIDExists, "DID %v already exists", did)
+}
+
+func ErrInvalidDID(did DID) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidDID, "Invalid DID %v", did)
+}
+
+func ErrInvalidDIDDocument() sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidDIDDocument, "Invalid DID Document")
+}
+
+func ErrDIDNotFound(did DID) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeDIDNotFound, "DID %v not found", did)
+}
+
+func ErrInvalidSignature(sig []byte) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidSignature, "Invalid signature %v", sig)
+}
+
+func ErrPubKeyIDNotFound(id PubKeyID) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodePubKeyIDNotFound, "PubKeyID %v not found", id)
+}
+
+func ErrSigVerificationFailed() sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeSigVerificationFailed, "Signature verification was failed")
+}
+
+func ErrInvalidSecp256k1PrivateKey(err error) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidSecp256k1PrivateKey, "Invalid Secp256k1 private key: %v", err)
+}
+
+func ErrInvalidSecp256k1PublicKey(err error) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidSecp256k1PublicKey, "Invalid Secp256k1 public key: %v", err)
+}

--- a/x/did/types/errors.go
+++ b/x/did/types/errors.go
@@ -16,6 +16,7 @@ const (
 	CodeSigVerificationFailed      sdk.CodeType = 107
 	CodeInvalidSecp256k1PrivateKey sdk.CodeType = 108
 	CodeInvalidSecp256k1PublicKey  sdk.CodeType = 109
+	CodeInvalidNetworkID  sdk.CodeType = 110
 )
 
 func ErrDIDExists(did DID) sdk.Error {
@@ -52,4 +53,8 @@ func ErrInvalidSecp256k1PrivateKey(err error) sdk.Error {
 
 func ErrInvalidSecp256k1PublicKey(err error) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidSecp256k1PublicKey, "Invalid Secp256k1 public key: %v", err)
+}
+
+func ErrInvalidNetworkID(id string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidNetworkID, "Invalid network ID: %s", id)
 }

--- a/x/did/types/keys.go
+++ b/x/did/types/keys.go
@@ -1,0 +1,15 @@
+package types
+
+const (
+	// module name
+	ModuleName = "did"
+
+	// StoreKey to be used when creating the KVStore
+	StoreKey = ModuleName
+
+	// RouterKey to be used in router
+	RouterKey = ModuleName
+
+	// QuerierRoute is the query router key
+	QuerierRoute = ModuleName
+)

--- a/x/did/types/msgs.go
+++ b/x/did/types/msgs.go
@@ -1,0 +1,99 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var (
+	_ sdk.Msg = &MsgCreateDID{}
+	_ sdk.Msg = &MsgUpdateDID{}
+)
+
+// MsgCreateDID defines a CreateDID message.
+type MsgCreateDID struct {
+	DID          DID            `json:"did"`
+	Document     DIDDocument    `json:"document"`
+	OwnerAddress sdk.AccAddress `json:"owner_address"`
+}
+
+// NewMsgCreateDID is a constructor of MsgCreateDID.
+func NewMsgCreateDID(did DID, doc DIDDocument, ownerAddr sdk.AccAddress) MsgCreateDID {
+	return MsgCreateDID{did, doc, ownerAddr}
+}
+
+// Route returns the name of the module.
+func (msg MsgCreateDID) Route() string { return RouterKey }
+
+// Type returns the name of the action.
+func (msg MsgCreateDID) Type() string { return "create_did" }
+
+// VaValidateBasic runs stateless checks on the message.
+func (msg MsgCreateDID) ValidateBasic() sdk.Error {
+	if !msg.DID.IsValid() {
+		return ErrInvalidDID(msg.DID)
+	}
+	if !msg.Document.IsValid() {
+		return ErrInvalidDIDDocument()
+	}
+	if msg.OwnerAddress.Empty() {
+		return sdk.ErrInvalidAddress(msg.OwnerAddress.String())
+	}
+	return nil
+}
+
+// GetSignBytes returns the canonical byte representation of the message. Used to generate a signature.
+func (msg MsgCreateDID) GetSignBytes() []byte {
+	return sdk.MustSortJSON(didCodec.MustMarshalJSON(msg))
+}
+
+// GetSigners return the addresses of signers that must sign.
+func (msg MsgCreateDID) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.OwnerAddress}
+}
+
+// MsgUpdateDID defines a UpdateDID message.
+type MsgUpdateDID struct {
+	DID          DID            `json:"did"`
+	Document     DIDDocument    `json:"document"`
+	SigPubKeyID  PubKeyID       `json:"sig_pubkey_id"`
+	Signature    []byte         `json:"signature"`
+	OwnerAddress sdk.AccAddress `json:"owner_address"`
+}
+
+// NewMsgUpdateDID is a constructor of MsgUpdateDID.
+func NewMsgUpdateDID(did DID, doc DIDDocument, sigPubKeyID PubKeyID, sig []byte, ownerAddr sdk.AccAddress) MsgUpdateDID {
+	return MsgUpdateDID{did, doc, sigPubKeyID, sig, ownerAddr}
+}
+
+// Route returns the name of the module.
+func (msg MsgUpdateDID) Route() string { return RouterKey }
+
+// Type returns the name of the action.
+func (msg MsgUpdateDID) Type() string { return "update_did" }
+
+// VaValidateBasic runs stateless checks on the message.
+func (msg MsgUpdateDID) ValidateBasic() sdk.Error {
+	if !msg.DID.IsValid() {
+		return ErrInvalidDID(msg.DID)
+	}
+	if !msg.Document.IsValid() {
+		return ErrInvalidDIDDocument()
+	}
+	if msg.Signature == nil || len(msg.Signature) == 0 {
+		return ErrInvalidSignature(msg.Signature)
+	}
+	if msg.OwnerAddress.Empty() {
+		return sdk.ErrInvalidAddress(msg.OwnerAddress.String())
+	}
+	return nil
+}
+
+// GetSignBytes returns the canonical byte representation of the message. Used to generate a signature.
+func (msg MsgUpdateDID) GetSignBytes() []byte {
+	return sdk.MustSortJSON(didCodec.MustMarshalJSON(msg))
+}
+
+// GetSigners return the addresses of signers that must sign.
+func (msg MsgUpdateDID) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.OwnerAddress}
+}

--- a/x/did/types/msgs.go
+++ b/x/did/types/msgs.go
@@ -29,10 +29,10 @@ func (msg MsgCreateDID) Type() string { return "create_did" }
 
 // VaValidateBasic runs stateless checks on the message.
 func (msg MsgCreateDID) ValidateBasic() sdk.Error {
-	if !msg.DID.IsValid() {
+	if !msg.DID.Valid() {
 		return ErrInvalidDID(msg.DID)
 	}
-	if !msg.Document.IsValid() {
+	if !msg.Document.Valid() {
 		return ErrInvalidDIDDocument()
 	}
 	if msg.OwnerAddress.Empty() {
@@ -73,10 +73,10 @@ func (msg MsgUpdateDID) Type() string { return "update_did" }
 
 // VaValidateBasic runs stateless checks on the message.
 func (msg MsgUpdateDID) ValidateBasic() sdk.Error {
-	if !msg.DID.IsValid() {
+	if !msg.DID.Valid() {
 		return ErrInvalidDID(msg.DID)
 	}
-	if !msg.Document.IsValid() {
+	if !msg.Document.Valid() {
 		return ErrInvalidDIDDocument()
 	}
 	if msg.Signature == nil || len(msg.Signature) == 0 {

--- a/x/did/types/msgs.go
+++ b/x/did/types/msgs.go
@@ -11,14 +11,14 @@ var (
 
 // MsgCreateDID defines a CreateDID message.
 type MsgCreateDID struct {
-	DID          DID            `json:"did"`
-	Document     DIDDocument    `json:"document"`
-	OwnerAddress sdk.AccAddress `json:"owner_address"`
+	DID         DID            `json:"did"`
+	Document    DIDDocument    `json:"document"`
+	FromAddress sdk.AccAddress `json:"from_address"`
 }
 
 // NewMsgCreateDID is a constructor of MsgCreateDID.
-func NewMsgCreateDID(did DID, doc DIDDocument, ownerAddr sdk.AccAddress) MsgCreateDID {
-	return MsgCreateDID{did, doc, ownerAddr}
+func NewMsgCreateDID(did DID, doc DIDDocument, fromAddr sdk.AccAddress) MsgCreateDID {
+	return MsgCreateDID{did, doc, fromAddr}
 }
 
 // Route returns the name of the module.
@@ -35,8 +35,8 @@ func (msg MsgCreateDID) ValidateBasic() sdk.Error {
 	if !msg.Document.Valid() {
 		return ErrInvalidDIDDocument()
 	}
-	if msg.OwnerAddress.Empty() {
-		return sdk.ErrInvalidAddress(msg.OwnerAddress.String())
+	if msg.FromAddress.Empty() {
+		return sdk.ErrInvalidAddress(msg.FromAddress.String())
 	}
 	return nil
 }
@@ -48,21 +48,21 @@ func (msg MsgCreateDID) GetSignBytes() []byte {
 
 // GetSigners return the addresses of signers that must sign.
 func (msg MsgCreateDID) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{msg.OwnerAddress}
+	return []sdk.AccAddress{msg.FromAddress}
 }
 
 // MsgUpdateDID defines a UpdateDID message.
 type MsgUpdateDID struct {
-	DID          DID            `json:"did"`
-	Document     DIDDocument    `json:"document"`
-	SigPubKeyID  PubKeyID       `json:"sig_pubkey_id"`
-	Signature    []byte         `json:"signature"`
-	OwnerAddress sdk.AccAddress `json:"owner_address"`
+	DID         DID            `json:"did"`
+	Document    DIDDocument    `json:"document"`
+	SigPubKeyID PubKeyID       `json:"sig_pubkey_id"`
+	Signature   []byte         `json:"signature"`
+	FromAddress sdk.AccAddress `json:"from_address"`
 }
 
 // NewMsgUpdateDID is a constructor of MsgUpdateDID.
-func NewMsgUpdateDID(did DID, doc DIDDocument, sigPubKeyID PubKeyID, sig []byte, ownerAddr sdk.AccAddress) MsgUpdateDID {
-	return MsgUpdateDID{did, doc, sigPubKeyID, sig, ownerAddr}
+func NewMsgUpdateDID(did DID, doc DIDDocument, sigPubKeyID PubKeyID, sig []byte, fromAddr sdk.AccAddress) MsgUpdateDID {
+	return MsgUpdateDID{did, doc, sigPubKeyID, sig, fromAddr}
 }
 
 // Route returns the name of the module.
@@ -82,8 +82,8 @@ func (msg MsgUpdateDID) ValidateBasic() sdk.Error {
 	if msg.Signature == nil || len(msg.Signature) == 0 {
 		return ErrInvalidSignature(msg.Signature)
 	}
-	if msg.OwnerAddress.Empty() {
-		return sdk.ErrInvalidAddress(msg.OwnerAddress.String())
+	if msg.FromAddress.Empty() {
+		return sdk.ErrInvalidAddress(msg.FromAddress.String())
 	}
 	return nil
 }
@@ -95,5 +95,5 @@ func (msg MsgUpdateDID) GetSignBytes() []byte {
 
 // GetSigners return the addresses of signers that must sign.
 func (msg MsgUpdateDID) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{msg.OwnerAddress}
+	return []sdk.AccAddress{msg.FromAddress}
 }


### PR DESCRIPTION
**NOTE:**
I didn't create a `dev` branch. All PRs would be based on `master` (aka. [trunk-based approach](https://www.toptal.com/software/trunk-based-development-git-flow) that the `master` is always a source-of-truth). It means that all PRs must be reliable.

### Changes
- A new feature for creating/resolving/updating DIDs

### Tests
- Manually done by a new CLI command.
```
~ ❯❯❯ panaceacli tx did create-did --chain-id=testing --from=panacea1zyfxqj425wf5zzquagyqden5xekhd94srrxuh5
{"chain_id":"testing","account_number":"0","sequence":"3","fee":{"amount":null,"gas":"200000"},"msgs":[{"type":"did/MsgCreateDID","value":{"did":"did:panacea:testnet:LPSAj6BKigRM8t4vAqT11","document":{"id":"did:panacea:testnet:LPSAj6BKigRM8t4vAqT11","publicKey":[{"id":"key1","type":"Secp256k1VerificationKey","publicKeyBase58":"oe1oi7s46UQMMuuFEULbF6uyf3Bho2rLdrRqDkVfyGsm"}],"authentication":["key1"]},"owner_address":"panacea1zyfxqj425wf5zzquagyqden5xekhd94srrxuh5"}}],"memo":""}

confirm transaction before signing and broadcasting [Y/n]: y
Password to sign with 'validator':
Response:
  TxHash: 5F7DCFE8D516683D6FFE1DECDEFE01FD5F158A720C03AD0207AB02745DC93A8B
```
```
~ ❯❯❯ panaceacli query did resolve-did did:panacea:testnet:HZKXqBuUuqGT76gLwAXwd --chain-id=testing | jq
{
  "id": "did:panacea:testnet:HZKXqBuUuqGT76gLwAXwd",
  "publicKey": [
    {
      "id": "key1",
      "type": "Secp256k1VerificationKey2018",
      "publicKeyBase58": "gqD8mrPmTQwbSFBRR7VwmpERnpqrYiSo8KinSFgPiswy"
    }
  ],
  "authentication": [
    "key1"
  ]
}
```

### TODO
- Support REST API
- The private key management for DIDs (similar as the key management of Panacea accounts)
- Other DID operations (delete)
- Tests, CI