### PR TITLE
Implement DID keystore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /src
 COPY . .
 
 # build panacea-core
-RUN make build
+RUN make clean && make build
 
 
 # Final image

--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,9 @@ get_tools:
 go.sum: go.mod
 	@echo "--> Ensure dependencies have not been modified"
 	@go mod verify
+
+########################################
+### Clean
+
+clean:
+	rm -rf build/

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,14 @@ require (
 	github.com/cosmos/cosmos-sdk v0.34.7
 	github.com/golangci/golangci-lint v1.22.2 // indirect
 	github.com/gorilla/mux v1.7.0
+	github.com/pborman/uuid v1.2.1
 	github.com/rakyll/statik v0.1.6
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0
 	github.com/tendermint/go-amino v0.15.0
 	github.com/tendermint/tendermint v0.31.9
+	golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d
 	golang.org/x/sys v0.0.0-20190911201528-7ad0cfa0b7b5 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.0 h1:tOSd0UKHQd6urX6ApfOn4XdBMY6Sh1MfxV3kmaazO+U=
@@ -244,6 +245,8 @@ github.com/otiai10/copy v0.0.0-20180813032824-7e9a647135a1/go.mod h1:pXzZSDlN+HP
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.2.3/go.mod h1:YnfyPNhBvnY8bW4SGQHCs/aAFhkgySlMZbrF5U0bOVw=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
+github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/x/did/client/cli/query.go
+++ b/x/did/client/cli/query.go
@@ -23,7 +23,7 @@ func GetCmdResolveDID(cdc *codec.Codec) *cobra.Command {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			id := types.DID(args[0])
 			if !id.Valid() {
-				return types.ErrInvalidDID(id)
+				return types.ErrInvalidDID(args[0])
 			}
 
 			params := did.ResolveDIDParams{id}

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -2,17 +2,21 @@ package cli
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/btcsuite/btcutil/base58"
+	"os"
+	"path/filepath"
+
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/utils"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
+	"github.com/medibloc/panacea-core/x/did/client/keystore"
 	"github.com/medibloc/panacea-core/x/did/types"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
-	"os"
+	"github.com/tendermint/tendermint/libs/cli"
 )
 
 func GetCmdCreateDID(cdc *codec.Codec) *cobra.Command {
@@ -24,8 +28,7 @@ func GetCmdCreateDID(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
 
-			privKey := secp256k1.GenPrivKey()      //TODO: implement wallet
-			fmt.Println(base58.Encode(privKey[:])) //TODO: don't print it. store it securely.
+			privKey := secp256k1.GenPrivKey() //TODO: use mnemonic
 			pubKey := privKey.PubKey()
 
 			networkID, err := types.NewNetworkID(args[0])
@@ -34,7 +37,26 @@ func GetCmdCreateDID(cdc *codec.Codec) *cobra.Command {
 			}
 
 			did := types.NewDID(networkID, pubKey, types.ES256K)
-			doc := types.NewDIDDocument(did, types.NewPubKey("key1", pubKey, types.ES256K))
+			keyID := types.NewKeyID(did, "key1")
+			doc := types.NewDIDDocument(did, types.NewPubKey(keyID, types.ES256K, pubKey))
+
+			passwd, err := client.GetCheckPassword(
+				"Enter a password to encrypt your key for DID to disk:",
+				"Repeat the password:",
+				client.BufferStdin(),
+			)
+			if err != nil {
+				return err
+			}
+
+			ks, err := keystore.NewKeyStore(keystoreBaseDir())
+			if err != nil {
+				return err
+			}
+			_, err = ks.Save(string(keyID), privKey[:], passwd)
+			if err != nil {
+				return err
+			}
 
 			msg := types.NewMsgCreateDID(did, doc, cliCtx.GetFromAddress())
 			if err := msg.ValidateBasic(); err != nil {
@@ -48,37 +70,47 @@ func GetCmdCreateDID(cdc *codec.Codec) *cobra.Command {
 
 func GetCmdUpdateDID(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-did [did] [priv-key-base58] [pub-key-id] [did-doc-path]",
+		Use:   "update-did [did] [key-id] [did-doc-path]",
 		Short: "Update a DID Document",
-		Args:  cobra.ExactArgs(4),
+		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
 
-			did := types.DID(args[0])
-			if !did.Valid() {
-				return types.ErrInvalidDID(did)
-			}
-
-			// private key which is corresponding to the public key registered in the DID document
-			// TODO: Don't get this via CLI arg. Implement Wallet.
-			privKey, err := types.NewPrivKeyFromBase58(args[1])
-			if err != nil {
-				return types.ErrInvalidSecp256k1PrivateKey(err)
-			}
-			pubKeyID := types.PubKeyID(args[2])
-
-			// read an input file of DID document
-			file, err := os.Open(args[3])
+			did, err := types.NewDIDFrom(args[0])
 			if err != nil {
 				return err
 			}
-			defer file.Close()
+			keyID, err := types.NewKeyIDFrom(args[1])
+			if err != nil {
+				return err
+			}
+			// read an input file of DID document
+			doc, err := readDIDDocFrom(args[2])
+			if err != nil {
+				return err
+			}
 
-			var doc types.DIDDocument
-			err = json.NewDecoder(file).Decode(&doc)
-			if err != nil || !doc.Valid() {
-				return types.ErrInvalidDIDDocument()
+			passwd, err := client.GetPassword(
+				"Enter a password to decrypt your key for DID on disk:",
+				client.BufferStdin(),
+			)
+			if err != nil {
+				return err
+			}
+
+			ks, err := keystore.NewKeyStore(keystoreBaseDir())
+			if err != nil {
+				return err
+			}
+			privKeyBytes, err := ks.LoadByAddress(string(keyID), passwd)
+			if err != nil {
+				return err
+			}
+
+			privKey, err := types.NewPrivKeyFromBytes(privKeyBytes)
+			if err != nil {
+				return err
 			}
 
 			// For proving that I know the private key
@@ -87,7 +119,7 @@ func GetCmdUpdateDID(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgUpdateDID(did, doc, pubKeyID, sig, cliCtx.GetFromAddress())
+			msg := types.NewMsgUpdateDID(did, doc, keyID, sig, cliCtx.GetFromAddress())
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
@@ -95,4 +127,25 @@ func GetCmdUpdateDID(cdc *codec.Codec) *cobra.Command {
 		},
 	}
 	return cmd
+}
+
+func keystoreBaseDir() string {
+	return filepath.Join(viper.GetString(cli.HomeFlag), "did_keystore")
+}
+
+func readDIDDocFrom(path string) (types.DIDDocument, error) {
+	var doc types.DIDDocument
+
+	file, err := os.Open(path)
+	if err != nil {
+		return doc, err
+	}
+	defer file.Close()
+
+	err = json.NewDecoder(file).Decode(&doc)
+	if err != nil || !doc.Valid() {
+		return doc, types.ErrInvalidDIDDocument()
+	}
+
+	return doc, nil
 }

--- a/x/did/client/keystore/keystore.go
+++ b/x/did/client/keystore/keystore.go
@@ -1,0 +1,307 @@
+package keystore
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/pborman/uuid"
+	"golang.org/x/crypto/scrypt"
+	"golang.org/x/crypto/sha3"
+)
+
+const (
+	version         = 3
+	kdf             = "scrypt"
+	scryptN         = 1 << 18
+	scryptP         = 1
+	scryptR         = 8
+	scryptDKLen     = 32
+	saltBytes       = 32
+	derivedKeyLen   = 32
+	cipherAlgorithm = "aes-128-ctr"
+)
+
+// KeyStore stores an encrypted private key on disk.
+// It implements the Web3 Secret Storage Definition: https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition.
+type KeyStore struct {
+	mtx     sync.RWMutex
+	baseDir string
+}
+
+// NewKeyStore creates a KeyStore using baseDir. If baseDir doesn't exists, it is created automatically.
+func NewKeyStore(baseDir string) (*KeyStore, error) {
+	if err := os.MkdirAll(baseDir, os.ModePerm); err != nil {
+		return nil, err
+	}
+
+	return &KeyStore{
+		baseDir: baseDir,
+	}, nil
+}
+
+// Save stores a key by encrypting it using passwd.
+// The address is the name of the key which can be anything such as a blockchain address or a DID key ID.
+// The address is used for generating a file name of the stored key.
+func (ks *KeyStore) Save(address string, key []byte, passwd string) (string, error) {
+	encryptedKey, err := encryptKey(address, key, passwd)
+	if err != nil {
+		return "", fmt.Errorf("fail to encrypt the key: %v", err)
+	}
+	return ks.save(address, encryptedKey)
+}
+
+func (ks *KeyStore) save(address string, key encryptedKey) (string, error) {
+	ks.mtx.Lock()
+	defer ks.mtx.Unlock()
+
+	path := ks.newPath(address)
+	if fileExists(path) {
+		return "", fmt.Errorf("file is already exists: %s", path)
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	if err := json.NewEncoder(file).Encode(key); err != nil {
+		return "", fmt.Errorf("fail to encode encryptedKey: %w", err)
+	}
+
+	return path, nil
+}
+
+// Load loads a key from path by decrypting it using passwd.
+func (ks *KeyStore) Load(path string, passwd string) ([]byte, error) {
+	encryptedKey, err := ks.load(path)
+	if err != nil {
+		return nil, err
+	}
+	return decryptKey(encryptedKey, passwd)
+}
+
+// LoadByAddress loads a key by decrypting it using passwd.
+// If there are multiple files related to the address, it uses the recent one.
+func (ks *KeyStore) LoadByAddress(address string, passwd string) ([]byte, error) {
+	ks.mtx.RLock()
+	defer ks.mtx.RUnlock()
+
+	path, err := ks.recentPath(address)
+	if err != nil {
+		return nil, err
+	}
+
+	return ks.Load(path, passwd)
+}
+
+func (ks *KeyStore) load(path string) (encryptedKey, error) {
+	var key encryptedKey
+
+	ks.mtx.RLock()
+	defer ks.mtx.RUnlock()
+
+	file, err := os.Open(path)
+	if err != nil {
+		return key, err
+	}
+	defer file.Close()
+
+	if err := json.NewDecoder(file).Decode(&key); err != nil {
+		return key, fmt.Errorf("fail to decode encryptedKey: %w", err)
+	}
+	return key, nil
+}
+
+func (ks *KeyStore) newPath(address string) string {
+	return filepath.Join(
+		ks.baseDir,
+		fmt.Sprintf(
+			"UTC--%s--%s.json",
+			time.Now().UTC().Format("2006-01-02T15-04-05.000000000Z"),
+			address,
+		),
+	)
+}
+
+func (ks *KeyStore) recentPath(address string) (string, error) {
+	matches, err := filepath.Glob(fmt.Sprintf("%s/UTC--*--%s.json", ks.baseDir, address))
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("file not found for address: %s", address)
+	}
+
+	recentPath := ""
+	for _, match := range matches {
+		if recentPath < match {
+			recentPath = match
+		}
+	}
+	return recentPath, nil
+}
+
+// encryptKey encrypts a private key into a JSON using the Scrypt KDF .
+func encryptKey(address string, key []byte, passwd string) (encryptedKey, error) {
+	// generate a random salt
+	salt := make([]byte, saltBytes)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return encryptedKey{}, fmt.Errorf("fail to get random for salt: %w", err)
+	}
+
+	// derivedKey from the Scrypt KDF
+	derivedKey, err := scrypt.Key([]byte(passwd), salt, scryptN, scryptR, scryptP, scryptDKLen)
+	if err != nil {
+		return encryptedKey{}, err
+	}
+
+	// 128-bit initialisation vector for the cipher
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return encryptedKey{}, fmt.Errorf("fail to get random for iv: %w", err)
+	}
+
+	// encrypt the key using AES-128-CTR
+	cipherText, err := aesCTRXOR(derivedKey[:derivedKeyLen/2], iv, key[:])
+	if err != nil {
+		return encryptedKey{}, err
+	}
+
+	// MAC to check whether the decryption password was correct or not
+	mac := newSHA3Keccak256(derivedKey[derivedKeyLen/2:derivedKeyLen], cipherText)
+
+	// return a struct which can be marshalled as JSON
+	return encryptedKey{
+		Version: version,
+		ID:      uuid.NewRandom().String(),
+		Address: address,
+		Crypto: cryptoParams{
+			Cipher:     cipherAlgorithm,
+			CipherText: hex.EncodeToString(cipherText),
+			CipherParams: cipherParams{
+				IV: hex.EncodeToString(iv),
+			},
+			KDF: kdf,
+			KDFParams: kdfParams{
+				N:     scryptN,
+				R:     scryptR,
+				P:     scryptP,
+				DKLen: scryptDKLen,
+				Salt:  hex.EncodeToString(salt),
+			},
+			MAC: hex.EncodeToString(mac),
+		},
+	}, nil
+}
+
+func decryptKey(key encryptedKey, passwd string) ([]byte, error) {
+	// validate params
+	if key.Version != version {
+		return nil, fmt.Errorf("unsupported encryption version: %d", key.Version)
+	}
+	if key.Crypto.Cipher != cipherAlgorithm {
+		return nil, fmt.Errorf("unsupported cipher algorithm: %s", key.Crypto.Cipher)
+	}
+	if key.Crypto.KDF != kdf {
+		return nil, fmt.Errorf("unsupported kdf: %s", key.Crypto.Cipher)
+	}
+
+	mac, err := hex.DecodeString(key.Crypto.MAC)
+	if err != nil {
+		return nil, fmt.Errorf("fail to decode mac: %w", err)
+	}
+
+	iv, err := hex.DecodeString(key.Crypto.CipherParams.IV)
+	if err != nil {
+		return nil, fmt.Errorf("fail to decode iv: %w", err)
+	}
+
+	cipherText, err := hex.DecodeString(key.Crypto.CipherText)
+	if err != nil {
+		return nil, fmt.Errorf("fail to decode cipherText: %w", err)
+	}
+
+	salt, err := hex.DecodeString(key.Crypto.KDFParams.Salt)
+	if err != nil {
+		return nil, fmt.Errorf("fail to decode salt: %w", err)
+	}
+
+	derivedKey, err := scrypt.Key([]byte(passwd), salt, key.Crypto.KDFParams.N, key.Crypto.KDFParams.R, key.Crypto.KDFParams.P, key.Crypto.KDFParams.DKLen)
+	if err != nil {
+		return nil, fmt.Errorf("fail to derive a key: %w", err)
+	}
+
+	expectedMac := newSHA3Keccak256(derivedKey[derivedKeyLen/2:derivedKeyLen], cipherText)
+	if !bytes.Equal(expectedMac, mac) {
+		return nil, fmt.Errorf("mac verification was failed. the password might be wrong.")
+	}
+
+	return aesCTRXOR(derivedKey[:derivedKeyLen/2], iv, cipherText)
+}
+
+type encryptedKey struct {
+	Version int          `json:"version"`
+	ID      string       `json:"id"`
+	Address string       `json:"address"`
+	Crypto  cryptoParams `json:"crypto"`
+}
+
+type cryptoParams struct {
+	Cipher       string       `json:"cipher"`
+	CipherText   string       `json:"ciphertext"`
+	CipherParams cipherParams `json:"cipherparams"`
+	KDF          string       `json:"kdf"`
+	KDFParams    kdfParams    `json:"kdfparams"`
+	MAC          string       `json:"mac"`
+}
+
+type cipherParams struct {
+	IV string `json:"iv"`
+}
+
+type kdfParams struct {
+	N     int    `json:"n"`
+	R     int    `json:"r"`
+	P     int    `json:"p"`
+	DKLen int    `json:"dklen"`
+	Salt  string `json:"salt"`
+}
+
+// aesCTRXOR encrypts or decrypts a data using key and iv (bi-directional function).
+func aesCTRXOR(key, iv, data []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("fail to get a new cipher: %w", err)
+	}
+
+	buf := make([]byte, len(data))
+	cipher.NewCTR(block, iv).XORKeyStream(buf, data)
+	return buf, nil
+}
+
+// newSHA3Keccak256 calculates a SHA3-256 (Keccak256).
+func newSHA3Keccak256(data ...[]byte) []byte {
+	hash := sha3.New256()
+	for _, b := range data {
+		hash.Write(b)
+	}
+	return hash.Sum(nil)
+}
+
+func fileExists(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/x/did/client/keystore/keystore_test.go
+++ b/x/did/client/keystore/keystore_test.go
@@ -1,0 +1,75 @@
+package keystore_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/medibloc/panacea-core/x/did/client/keystore"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+)
+
+var (
+	baseDir = "my_keystore"
+	address = "did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1"
+	passwd  = "nein-danke"
+	priv    = secp256k1.GenPrivKey()
+)
+
+func TestKeyStore_SaveAndLoad(t *testing.T) {
+	ks := newKeyStore(t)
+
+	path, err := ks.Save(address, priv[:], passwd)
+	require.NoError(t, err)
+	require.NotEmpty(t, path)
+
+	loadedPriv, err := ks.Load(path, passwd)
+	require.NoError(t, err)
+	require.Equal(t, priv[:], loadedPriv)
+}
+
+func TestKeyStore_Load_WithInvalidPath(t *testing.T) {
+	ks := newKeyStore(t)
+	path, _ := ks.Save(address, priv[:], passwd)
+	_, err := ks.Load(path+path, passwd)
+	require.Error(t, err)
+}
+
+func TestKeyStore_Load_WithInvalidPassword(t *testing.T) {
+	ks := newKeyStore(t)
+	path, _ := ks.Save(address, priv[:], passwd)
+	_, err := ks.Load(path, passwd+passwd)
+	require.Error(t, err)
+}
+
+func TestKeyStore_LoadByAddress_RecentFile(t *testing.T) {
+	ks := newKeyStore(t)
+	ks.Save(address, priv[:], passwd)
+
+	newPriv := secp256k1.GenPrivKey()
+	ks.Save(address, newPriv[:], passwd)
+
+	privBytes, err := ks.LoadByAddress(address, passwd)
+	require.NoError(t, err)
+	require.Equal(t, newPriv[:], privBytes)
+}
+
+func TestKeyStore_LoadByAddress_NotExist(t *testing.T) {
+	ks := newKeyStore(t)
+	privBytes, err := ks.LoadByAddress(address, passwd)
+	require.Error(t, err)
+	require.Nil(t, privBytes)
+}
+
+func newKeyStore(t *testing.T) *keystore.KeyStore {
+	ks, err := keystore.NewKeyStore(baseDir)
+	require.NoError(t, err)
+	require.NotNil(t, ks)
+
+	t.Cleanup(func() {
+		os.RemoveAll(baseDir)
+	})
+
+	return ks
+}

--- a/x/did/handler.go
+++ b/x/did/handler.go
@@ -37,9 +37,9 @@ func handleMsgUpdateDID(ctx sdk.Context, keeper Keeper, msg MsgUpdateDID) sdk.Re
 		return types.ErrDIDNotFound(msg.DID).Result()
 	}
 
-	pubKey, ok := curDoc.PubKeyByID(msg.SigPubKeyID)
+	pubKey, ok := curDoc.PubKeyByID(msg.SigKeyID)
 	if !ok {
-		return types.ErrPubKeyIDNotFound(msg.SigPubKeyID).Result()
+		return types.ErrKeyIDNotFound(msg.SigKeyID).Result()
 	}
 
 	pubKeySecp256k1, err := types.NewPubKeyFromBase58(pubKey.KeyBase58)

--- a/x/did/types/did_test.go
+++ b/x/did/types/did_test.go
@@ -98,37 +98,3 @@ func TestKeyType_Valid(t *testing.T) {
 	assert.True(t, ES256K.Valid())
 	assert.False(t, KeyType("invalid").Valid())
 }
-
-func TestPrivKey_Valid(t *testing.T) {
-	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
-	keyID := NewKeyID(did, "key1")
-
-	k := NewPrivKey(keyID, ES256K, secp256k1.GenPrivKey(), "passwd")
-	assert.True(t, k.Valid())
-
-	k = NewPrivKey("invalid_id", ES256K, secp256k1.GenPrivKey(), "passwd")
-	assert.False(t, k.Valid())
-
-	k = NewPrivKey(keyID, "invalid_type", secp256k1.GenPrivKey(), "passwd")
-	assert.False(t, k.Valid())
-}
-
-func TestPrivKey_Decrypt(t *testing.T) {
-	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
-	keyID := NewKeyID(did, "key1")
-	privKey := secp256k1.GenPrivKey()
-	k := NewPrivKey(keyID, ES256K, privKey, "passwd")
-
-	decrypted, err := k.Decrypt("passwd")
-	assert.NoError(t, err)
-	assert.Equal(t, privKey, decrypted)
-
-	_, err = k.Decrypt("wrong_passwd")
-	assert.EqualError(t, err, "invalid account password")
-}
-
-func TestNewPubKey(t *testing.T) {
-	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
-	keyID := NewKeyID(did, "key1")
-	k := NewPubKey(did, ES256K, secp256k1.GenPrivKey().PubKey())
-}

--- a/x/did/types/did_test.go
+++ b/x/did/types/did_test.go
@@ -1,0 +1,134 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+)
+
+func TestNewDID(t *testing.T) {
+	privKey := secp256k1.GenPrivKey()
+	pubKey := privKey.PubKey()
+
+	did := NewDID(Mainnet, pubKey, ES256K)
+	regex := fmt.Sprintf("^did:panacea:mainnet:[%s]{21,22}$", Base58Charset)
+	require.Regexp(t, regex, did)
+}
+
+func TestNewDIDFrom(t *testing.T) {
+	str := "did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"
+	did, err := NewDIDFrom(str)
+	assert.NoError(t, err)
+	assert.EqualValues(t, str, did)
+
+	str = "did:panacea:t1estnet:KS5zGZt66Me8MCctZBYrP"
+	_, err = NewDIDFrom(str)
+	require.EqualError(t, err, ErrInvalidDID(str).Error())
+}
+
+func TestDID_Empty(t *testing.T) {
+	assert.True(t, DID("").Empty())
+	assert.False(t, DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP").Empty())
+}
+
+func TestNewNetworkID(t *testing.T) {
+	id, err := NewNetworkID("mainnet")
+	assert.NoError(t, err)
+	assert.Equal(t, Mainnet, id)
+
+	id, err = NewNetworkID("testnet")
+	assert.NoError(t, err)
+	assert.Equal(t, Testnet, id)
+
+	_, err = NewNetworkID("testn124et")
+	assert.EqualError(t, err, ErrInvalidNetworkID("testn124et").Error())
+}
+
+func TestNewDIDDocument(t *testing.T) {
+	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
+	keyID := NewKeyID(did, "key1")
+	pubKey := NewPubKey(keyID, ES256K, secp256k1.GenPrivKey().PubKey())
+
+	doc := NewDIDDocument(did, pubKey)
+	assert.True(t, doc.Valid())
+	assert.Equal(t, did, doc.ID)
+	assert.Equal(t, 1, len(doc.PubKeys))
+	assert.Equal(t, pubKey, doc.PubKeys[0])
+	assert.Equal(t, 1, len(doc.Authentications))
+	assert.EqualValues(t, keyID, doc.Authentications[0])
+
+	pubKeyFound, ok := doc.PubKeyByID(keyID)
+	assert.True(t, ok)
+	assert.Equal(t, pubKey, *pubKeyFound)
+
+	_, ok = doc.PubKeyByID("invalid_key_id")
+	assert.False(t, ok)
+}
+
+func TestDIDDocument_Empty(t *testing.T) {
+	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
+	keyID := NewKeyID(did, "key1")
+	pubKey := NewPubKey(keyID, ES256K, secp256k1.GenPrivKey().PubKey())
+	doc := NewDIDDocument(did, pubKey)
+	assert.False(t, doc.Empty())
+
+	assert.True(t, DIDDocument{}.Empty())
+}
+
+func TestNewKeyID(t *testing.T) {
+	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
+	expectedID := fmt.Sprintf("%s#key1", did)
+	id := NewKeyID(did, "key1")
+	assert.True(t, id.Valid())
+	assert.EqualValues(t, expectedID, id)
+
+	id, err := NewKeyIDFrom(expectedID)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expectedID, id)
+
+	_, err = NewKeyIDFrom("invalid_id")
+	assert.Error(t, err, ErrInvalidKeyID("invalid_id"))
+}
+
+func TestKeyType_Valid(t *testing.T) {
+	assert.True(t, ES256K.Valid())
+	assert.False(t, KeyType("invalid").Valid())
+}
+
+func TestPrivKey_Valid(t *testing.T) {
+	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
+	keyID := NewKeyID(did, "key1")
+
+	k := NewPrivKey(keyID, ES256K, secp256k1.GenPrivKey(), "passwd")
+	assert.True(t, k.Valid())
+
+	k = NewPrivKey("invalid_id", ES256K, secp256k1.GenPrivKey(), "passwd")
+	assert.False(t, k.Valid())
+
+	k = NewPrivKey(keyID, "invalid_type", secp256k1.GenPrivKey(), "passwd")
+	assert.False(t, k.Valid())
+}
+
+func TestPrivKey_Decrypt(t *testing.T) {
+	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
+	keyID := NewKeyID(did, "key1")
+	privKey := secp256k1.GenPrivKey()
+	k := NewPrivKey(keyID, ES256K, privKey, "passwd")
+
+	decrypted, err := k.Decrypt("passwd")
+	assert.NoError(t, err)
+	assert.Equal(t, privKey, decrypted)
+
+	_, err = k.Decrypt("wrong_passwd")
+	assert.EqualError(t, err, "invalid account password")
+}
+
+func TestNewPubKey(t *testing.T) {
+	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
+	keyID := NewKeyID(did, "key1")
+	k := NewPubKey(did, ES256K, secp256k1.GenPrivKey().PubKey())
+}

--- a/x/did/types/errors.go
+++ b/x/did/types/errors.go
@@ -7,23 +7,23 @@ import (
 const DefaultCodespace sdk.CodespaceType = ModuleName
 
 const (
-	CodeDIDExists                  sdk.CodeType = 101
-	CodeInvalidDID                 sdk.CodeType = 102
-	CodeInvalidDIDDocument         sdk.CodeType = 103
-	CodeDIDNotFound                sdk.CodeType = 104
-	CodeInvalidSignature           sdk.CodeType = 105
-	CodePubKeyIDNotFound           sdk.CodeType = 106
-	CodeSigVerificationFailed      sdk.CodeType = 107
-	CodeInvalidSecp256k1PrivateKey sdk.CodeType = 108
-	CodeInvalidSecp256k1PublicKey  sdk.CodeType = 109
-	CodeInvalidNetworkID  sdk.CodeType = 110
+	CodeDIDExists                 sdk.CodeType = 101
+	CodeInvalidDID                sdk.CodeType = 102
+	CodeInvalidDIDDocument        sdk.CodeType = 103
+	CodeDIDNotFound               sdk.CodeType = 104
+	CodeInvalidSignature          sdk.CodeType = 105
+	CodeInvalidKeyID              sdk.CodeType = 106
+	CodeKeyIDNotFound             sdk.CodeType = 107
+	CodeSigVerificationFailed     sdk.CodeType = 108
+	CodeInvalidSecp256k1PublicKey sdk.CodeType = 109
+	CodeInvalidNetworkID          sdk.CodeType = 110
 )
 
 func ErrDIDExists(did DID) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeDIDExists, "DID %v already exists", did)
 }
 
-func ErrInvalidDID(did DID) sdk.Error {
+func ErrInvalidDID(did string) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidDID, "Invalid DID %v", did)
 }
 
@@ -39,16 +39,16 @@ func ErrInvalidSignature(sig []byte) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidSignature, "Invalid signature %v", sig)
 }
 
-func ErrPubKeyIDNotFound(id PubKeyID) sdk.Error {
-	return sdk.NewError(DefaultCodespace, CodePubKeyIDNotFound, "PubKeyID %v not found", id)
+func ErrInvalidKeyID(id string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidKeyID, "Invalid KeyID: %s", id)
+}
+
+func ErrKeyIDNotFound(id KeyID) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeKeyIDNotFound, "KeyID %v not found", id)
 }
 
 func ErrSigVerificationFailed() sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeSigVerificationFailed, "Signature verification was failed")
-}
-
-func ErrInvalidSecp256k1PrivateKey(err error) sdk.Error {
-	return sdk.NewError(DefaultCodespace, CodeInvalidSecp256k1PrivateKey, "Invalid Secp256k1 private key: %v", err)
 }
 
 func ErrInvalidSecp256k1PublicKey(err error) sdk.Error {

--- a/x/did/types/msgs.go
+++ b/x/did/types/msgs.go
@@ -30,7 +30,7 @@ func (msg MsgCreateDID) Type() string { return "create_did" }
 // VaValidateBasic runs stateless checks on the message.
 func (msg MsgCreateDID) ValidateBasic() sdk.Error {
 	if !msg.DID.Valid() {
-		return ErrInvalidDID(msg.DID)
+		return ErrInvalidDID(string(msg.DID))
 	}
 	if !msg.Document.Valid() {
 		return ErrInvalidDIDDocument()
@@ -55,14 +55,14 @@ func (msg MsgCreateDID) GetSigners() []sdk.AccAddress {
 type MsgUpdateDID struct {
 	DID         DID            `json:"did"`
 	Document    DIDDocument    `json:"document"`
-	SigPubKeyID PubKeyID       `json:"sig_pubkey_id"`
+	SigKeyID    KeyID          `json:"sig_key_id"`
 	Signature   []byte         `json:"signature"`
 	FromAddress sdk.AccAddress `json:"from_address"`
 }
 
 // NewMsgUpdateDID is a constructor of MsgUpdateDID.
-func NewMsgUpdateDID(did DID, doc DIDDocument, sigPubKeyID PubKeyID, sig []byte, fromAddr sdk.AccAddress) MsgUpdateDID {
-	return MsgUpdateDID{did, doc, sigPubKeyID, sig, fromAddr}
+func NewMsgUpdateDID(did DID, doc DIDDocument, sigKeyID KeyID, sig []byte, fromAddr sdk.AccAddress) MsgUpdateDID {
+	return MsgUpdateDID{did, doc, sigKeyID, sig, fromAddr}
 }
 
 // Route returns the name of the module.
@@ -74,7 +74,7 @@ func (msg MsgUpdateDID) Type() string { return "update_did" }
 // VaValidateBasic runs stateless checks on the message.
 func (msg MsgUpdateDID) ValidateBasic() sdk.Error {
 	if !msg.DID.Valid() {
-		return ErrInvalidDID(msg.DID)
+		return ErrInvalidDID(string(msg.DID))
 	}
 	if !msg.Document.Valid() {
 		return ErrInvalidDIDDocument()


### PR DESCRIPTION
Close #17 

Whenever DID is created, the private key should be stored securely on disk, so that it can be reusable.
I've implemented the `x/did/client/keystore` package by generalizing the [Web3 Secret Storage Definition](https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition) which is defined by Ethereum.
The keystore can be used for any type of private keys, such as blockchain account or DID.

I didn't use the Leveldb which is used by `panaceacli` internally, because it's tightly coupled with the blockchain account concept and it's not compatible with other programming languages.

A private key is stored like below. Note that the `address` is used for the DID key ID (`did#key-x`). The `address` can be anything you want.
```
$ cat "/root/.panaceacli/did_keystore/UTC--2020-08-23T01-07-21.275360700Z--did:panacea:testnet:KFLxc5GxDSKTjwojKyaCF#key1.json" | jq

{
  "version": 3,
  "id": "1c52b172-bf7f-45dc-902a-77d5fc1392ca",
  "address": "did:panacea:testnet:KFLxc5GxDSKTjwojKyaCF#key1",
  "crypto": {
    "cipher": "aes-128-ctr",
    "ciphertext": "aea68a28f33aabc526e4152e488e7c600161fc9cb4c5bdebc3a26f8f2133cf02",
    "cipherparams": {
      "iv": "91f5a620ab2e6eef1e0295a643f385d5"
    },
    "kdf": "scrypt",
    "kdfparams": {
      "n": 262144,
      "r": 8,
      "p": 1,
      "dklen": 32,
      "salt": "2d0028a7a28effae318c3e111545dc65f949ba7613d2d135431df8d64ccbfc42"
    },
    "mac": "a81d41edca1b232818ff6ec1cb996688d00c33b143d4af4a302066400cff3708"
  }
}
```

TODO:
- Use mnemonic for generated a key-pair.
- CLI for generating/storing a private key independently with `create-did`, so that it can be used for `update-did` or any other DIDs.