### PR TITLE
Add an option for using BIP39 mnemonic to create DID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bombsimon/wsl v1.2.1 // indirect
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/cosmos/cosmos-sdk v0.34.7
+	github.com/cosmos/go-bip39 v0.0.0-20180618194314-52158e4697b8
 	github.com/golangci/golangci-lint v1.22.2 // indirect
 	github.com/gorilla/mux v1.7.0
 	github.com/rakyll/statik v0.1.6

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -61,7 +61,8 @@ func GetCmdCreateDID(cdc *codec.Codec) *cobra.Command {
 			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg}, false)
 		},
 	}
-	cmd.Flags().Bool(flagInteractive, false, "Use BIP39 Mnemonic to generate a private key")
+
+	cmd.Flags().Bool(flagInteractive, false, "Interactively prompt user for BIP39 mnemonic and passphrase")
 	return cmd
 }
 

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -146,7 +146,6 @@ func genPrivKey(interactive bool) (secp256k1.PrivKeySecp256k1, error) {
 		return secp256k1.PrivKeySecp256k1{}, err
 	}
 
-	//TODO: can I use this?
 	hdPath := hd.NewFundraiserParams(defaultAccountForHD, sdk.GetConfig().GetCoinType(), defaultIndexForHD).String()
 	masterPriv, chainCode := hd.ComputeMastersFromSeed(seed)
 	return hd.DerivePrivateKeyForPath(masterPriv, chainCode, hdPath)


### PR DESCRIPTION
Close #21 

If the option `--use-mnemonic` is specified, the CLI accepts a BIP39 mnemonic and a passphrase.

```
~ ❯❯❯ docker exec -it testing1 panaceacli tx did create-did testnet --use-mnemonic --chain-id=testing --from=panacea1ee4adg8uk26tllsu5yu3x8v9lz2xur0lvl6qy7                                                                                              ✘ 1
> Enter your BIP39 mnemonic, or hit enter to generate one:

A random mnemonic was generated: exotic suspect harsh hungry believe saddle cup nose master consider little senior thing recall hood glare same lemon lion arrest thrive depth uphold razor
Enter your BIP39 passphrase:
Repeat the password:

{"chain_id":"testing","account_number":"0","sequence":"1","fee":{"amount":null,"gas":"200000"},"msgs":[{"type":"did/MsgCreateDID","value":{"did":"did:panacea:testnet:VL7qptoMiHJWNJMKCr2N7","document":{"id":"did:panacea:testnet:VL7qptoMiHJWNJMKCr2N7","publicKey":[{"id":"key1","type":"Secp256k1VerificationKey2018","publicKeyBase58":"2B9o7h7md1qh3ShaDoXaE7sjcKApQm7yrBth9GeHZ9zUe"}],"authentication":["key1"]},"from_address":"panacea1ee4adg8uk26tllsu5yu3x8v9lz2xur0lvl6qy7"}}],"memo":""}

confirm transaction before signing and broadcasting [Y/n]: y
Password to sign with 'validator':
Response:
  TxHash: 6A030C272B4D7FB8EC581281097BA32E5906F38D1E3324FB19D05FE499B138C6
```