### PR TITLE
CI: add code-coverage and make the 'lint' stage faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .idea/
 *.iml
 build/
+
+# artifacts
+artifacts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
 RUN apk add --no-cache $PACKAGES
 
 # Install minimum Go tools
-RUN go get github.com/golangci/golangci-lint/cmd/golangci-lint
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 
 # Set working directory for the build
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ FROM golang:alpine AS build-env
 ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
 RUN apk add --no-cache $PACKAGES
 
+# Install minimum Go tools
+RUN go get github.com/golangci/golangci-lint/cmd/golangci-lint
+
 # Set working directory for the build
 WORKDIR /src
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
         GIT_COMMIT_HASH = sh (script: "git log -n 1 --pretty=format:'%H'", returnStdout: true)
 	    IMAGE_NAME = "${APP_NAME}:${GIT_COMMIT_HASH}"
 	    IMAGE_NAME_BUILD_ENV= "${IMAGE_NAME}-build-env"
-	    ARTIFACT_DIR = "./artifacts"
+	    ARTIFACT_DIR = "${WORKSPACE}/artifacts"
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
         stage('Analyze') {
             steps {
                 echo 'Analyzing..'
-                sh 'docker run --rm ${IMAGE_NAME_BUILD_ENV} make get_tools lint'
+                sh 'docker run --rm ${IMAGE_NAME_BUILD_ENV} make lint'
             }
         }
         stage('Deploy') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,10 +47,10 @@ pipeline {
                     allowMissing: false,
                     alwaysLinkToLastBuild: false,
                     keepAll: false,
-                    reportDir: '${ARTIFACT_DIR}',
+                    reportDir: 'env.ARTIFACT_DIR',
                     reportFiles: 'coverage.html',
                     reportName: 'Code Coverage',
-                    reportTitles: '${APP_NAME} Code Coverage'
+                    reportTitles: 'env.APP_NAME Code Coverage'
                 ])
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         stage('Start') {
             steps {
                 slackSend (channel: '#alerts-ci', color: '#FFFF00', message: "STARTED: '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
-                sh 'mkdir -p ${ARTIFACT_DIR}'
+                sh 'rm -rf ${ARTIFACT_DIR} && mkdir -p ${ARTIFACT_DIR}'
             }
         }
         stage('Build') {
@@ -47,10 +47,10 @@ pipeline {
                     allowMissing: false,
                     alwaysLinkToLastBuild: false,
                     keepAll: false,
-                    reportDir: 'env.ARTIFACT_DIR',
+                    reportDir: "${ARTIFACT_DIR}",
                     reportFiles: 'coverage.html',
                     reportName: 'Code Coverage',
-                    reportTitles: 'env.APP_NAME Code Coverage'
+                    reportTitles: "${APP_NAME} Code Coverage"
                 ])
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ build: go.sum
 	go build -mod=readonly $(BUILD_FLAGS) -o build/panaceakeyutil ./cmd/panaceakeyutil
 
 test:
-	go test ./...
+	go test -coverprofile=coverage.out ./...
 
 update_panacea_lite_docs:
 	@statik -src=client/lcd/swagger-ui -dest=client/lcd -f

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 
+ARTIFACT_DIR := artifacts
+
 all: get_tools install
 
 ########################################
@@ -47,7 +49,9 @@ build: go.sum
 	go build -mod=readonly $(BUILD_FLAGS) -o build/panaceakeyutil ./cmd/panaceakeyutil
 
 test:
-	go test -coverprofile=coverage.out ./...
+	mkdir -p $(ARTIFACT_DIR)
+	go test -coverprofile=$(ARTIFACT_DIR)/coverage.out ./...
+	go tool cover -html=$(ARTIFACT_DIR)/coverage.out -o $(ARTIFACT_DIR)/coverage.html
 
 update_panacea_lite_docs:
 	@statik -src=client/lcd/swagger-ui -dest=client/lcd -f


### PR DESCRIPTION
See http://ci.medibloc.org/job/panacea-core/job/PR-32/. You can find the `Code Coverage` menu on the left side-bar.

Also, in `Dockerfile`, download the pre-built `golangci-lint`, instead of `go get .../golangci-lint` everytime.