### PR TITLE
Enable Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    name: Build
+    name: Build and Test
     runs-on: ubuntu-latest
     steps:
 
@@ -46,8 +46,20 @@ jobs:
         name: coverage
         path: artifacts/coverage.html
 
+    - name: Convert coverage to Cobertura
+      run: |
+        go get github.com/t-yuki/gocover-cobertura
+        gocover-cobertura < coverage.out > coverage.xml
+
+    - name: Report Cobertura report
+      uses: 5monkeys/cobertura-action@master
+      with:
+        path: coverage.xml
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        minimum_coverage: 50
+
   lint:
-    name: lint
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: panacea-core
+name: ci
 
 on:
   push:
@@ -32,6 +32,18 @@ jobs:
       uses: golangci/golangci-lint-action@v1.2.1
       with:
           version: v1.30
-      
+
     - name: Deploy
       run: echo "Deploying..."
+
+    - name: Convert coverage to lcov
+      uses: jandelgado/gcov2lcov-action@v1.0.2
+      with:
+        infile: artifacts/coverage.out
+        outfile: artifacts/coverage.lcov
+
+    - name: Report lcov
+      uses: romeovs/lcov-reporter-action@v0.2.16
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        lcov-file: artifacts/coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,35 +28,23 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Convert coverage to lcov
+    - name: Convert coverage.out to coverage.lcov
       uses: jandelgado/gcov2lcov-action@v1.0.2
       with:
         infile: artifacts/coverage.out
         outfile: artifacts/coverage.lcov
 
-    - name: Report lcov
+    - name: Report coverage.lcov as a comment
       uses: romeovs/lcov-reporter-action@v0.2.16
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         lcov-file: artifacts/coverage.lcov
 
-    - name: Report coverage HTML
+    - name: Publish coverage.html as an artifact
       uses: actions/upload-artifact@master
       with:
         name: coverage
         path: artifacts/coverage.html
-
-    - name: Convert coverage to Cobertura
-      run: |
-        go get github.com/t-yuki/gocover-cobertura
-        gocover-cobertura < coverage.out > coverage.xml
-
-    - name: Report Cobertura report
-      uses: 5monkeys/cobertura-action@master
-      with:
-        path: coverage.xml
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        minimum_coverage: 50
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Convert coverage.out to coverage.lcov
+    - name: Convert coverage.out into coverage.lcov
       uses: jandelgado/gcov2lcov-action@v1.0.2
       with:
         infile: artifacts/coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ jobs:
       with:
           version: v1.30
 
-    - name: Deploy
-      run: echo "Deploying..."
-
     - name: Convert coverage to lcov
       uses: jandelgado/gcov2lcov-action@v1.0.2
       with:
@@ -47,3 +44,9 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         lcov-file: artifacts/coverage.lcov
+
+    - name: Report coverage HTML
+      uses: actions/upload-artifact@master
+      with:
+        name: coverage
+        path: artifacts/coverage.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         path: artifacts/coverage.html
 
   lint:
+    # this action is recommended to be run as a separated job from other jobs (https://github.com/golangci/golangci-lint-action#how-to-use).
     name: Lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,6 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v1.2.1
-      with:
-          version: v1.30
-
     - name: Convert coverage to lcov
       uses: jandelgado/gcov2lcov-action@v1.0.2
       with:
@@ -50,3 +45,13 @@ jobs:
       with:
         name: coverage
         path: artifacts/coverage.html
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.30

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,33 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+
+    - name: Build
+      run: go build -v .
+
+    - name: Test
+      run: go test -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,11 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches:
+    - master
   pull_request:
-    branches: [ master ]
+    branches:
+    - master
 
 jobs:
 
@@ -16,18 +18,20 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.15
       id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
 
     - name: Build
       run: make build
 
     - name: Test
       run: make test
+
+    - name: Anaylze
+      run: make lint
+    
+    - name: Deploy
+      run: echo "Deploying..."

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
         go get -v -t -d ./...
 
     - name: Build
-      run: go build -v .
+      run: make build
 
     - name: Test
-      run: go test -v .
+      run: make test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v1.2.1
       with:
-          version: v1.30.0
+          version: v1.30
       
     - name: Deploy
       run: echo "Deploying..."

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,11 +2,9 @@ name: panacea-core
 
 on:
   push:
-    branches:
+    branches:    # only for pushes on master
     - master
-  pull_request:
-    branches:
-    - master
+  pull_request:  # for all PRs regardless of its base branch
 
 jobs:
 
@@ -32,6 +30,8 @@ jobs:
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v1.2.1
+      with:
+          version: v1.30.0
       
     - name: Deploy
       run: echo "Deploying..."

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: panacea-core
 
 on:
   push:
@@ -30,8 +30,8 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Anaylze
-      run: make lint
-    
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v1.2.1
+      
     - name: Deploy
       run: echo "Deploying..."

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build: go.sum
 
 test:
 	mkdir -p $(ARTIFACT_DIR)
-	go test -coverprofile=$(ARTIFACT_DIR)/coverage.out ./...
+	go test -covermode=count -coverprofile=$(ARTIFACT_DIR)/coverage.out ./...
 	go tool cover -html=$(ARTIFACT_DIR)/coverage.out -o $(ARTIFACT_DIR)/coverage.html
 
 update_panacea_lite_docs:


### PR DESCRIPTION
For experimental purposes, let's use Github Actions along with Jenkins for a while.

All good, except publishing the code coverage report...
There is no way to publish HTML reports as Jenkins supports. Many people are using proprietary coverage report services, such as Coverall. But, I don't want to pay for it. 

As work-around, I defined the following steps.
1. Convert `coverage.out` into `coverage.lcov`
2. Post a comment about the summary of `coverage.lcov`. You can find comments below.
3. Upload `coverage.html` as an artifact of Github Actions Job. You can find the artifact on this [link](https://github.com/medibloc/panacea-core/pull/33/checks?check_run_id=1034513451) (on the right side).