### PR TITLE
Add signature verification for CreateDID

### DIFF
--- a/x/did/client/cli/query.go
+++ b/x/did/client/cli/query.go
@@ -26,17 +26,17 @@ func GetCmdQueryDID(cdc *codec.Codec) *cobra.Command {
 				return types.ErrInvalidDID(args[0])
 			}
 
-			doc, err := queryDID(cliCtx, id)
+			docWithSeq, err := queryDIDDocumentWithSeq(cliCtx, id)
 			if err != nil {
 				return err
 			}
-			return cliCtx.PrintOutput(doc.Document)
+			return cliCtx.PrintOutput(docWithSeq.Document)
 		},
 	}
 	return cmd
 }
 
-func queryDID(cliCtx context.CLIContext, id types.DID) (types.DIDDocumentWithSeq, error) {
+func queryDIDDocumentWithSeq(cliCtx context.CLIContext, id types.DID) (types.DIDDocumentWithSeq, error) {
 	bz, err := cliCtx.Codec.MarshalJSON(did.QueryDIDParams{DID: id})
 	if err != nil {
 		return types.DIDDocumentWithSeq{}, err

--- a/x/did/handler.go
+++ b/x/did/handler.go
@@ -25,17 +25,30 @@ func NewHandler(keeper Keeper) sdk.Handler {
 }
 
 func handleMsgCreateDID(ctx sdk.Context, keeper Keeper, msg MsgCreateDID) sdk.Result {
-	if keeper.HasDID(ctx, msg.DID) {
+	cur := keeper.GetDIDDocument(ctx, msg.DID)
+	if !cur.Empty() {
 		return types.ErrDIDExists(msg.DID).Result()
 	}
 
-	docWithSeq := types.NewDIDDocumentWithSeq(msg.Document, types.NewSequence())
+	seq := types.NewSequence()
+
+	_, err := verifyDIDOwnership(msg.Document, seq, msg.Document, msg.SigKeyID, msg.Signature)
+	if err != nil {
+		return err.Result()
+	}
+
+	docWithSeq := types.NewDIDDocumentWithSeq(msg.Document, seq)
 	keeper.SetDIDDocument(ctx, msg.DID, docWithSeq)
 	return sdk.Result{}
 }
 
 func handleMsgUpdateDID(ctx sdk.Context, keeper Keeper, msg MsgUpdateDID) sdk.Result {
-	newSeq, err := verifyDIDOwnership(ctx, keeper, msg.DID, msg.SigKeyID, msg.Signature, msg.Document)
+	docWithSeq := keeper.GetDIDDocument(ctx, msg.DID)
+	if docWithSeq.Empty() {
+		return types.ErrDIDNotFound(msg.DID).Result()
+	}
+
+	newSeq, err := verifyDIDOwnership(msg.Document, docWithSeq.Seq, docWithSeq.Document, msg.SigKeyID, msg.Signature)
 	if err != nil {
 		return err.Result()
 	}
@@ -46,7 +59,12 @@ func handleMsgUpdateDID(ctx sdk.Context, keeper Keeper, msg MsgUpdateDID) sdk.Re
 }
 
 func handleMsgDeleteDID(ctx sdk.Context, keeper Keeper, msg MsgDeleteDID) sdk.Result {
-	_, err := verifyDIDOwnership(ctx, keeper, msg.DID, msg.SigKeyID, msg.Signature, msg.DID)
+	docWithSeq := keeper.GetDIDDocument(ctx, msg.DID)
+	if docWithSeq.Empty() {
+		return types.ErrDIDNotFound(msg.DID).Result()
+	}
+
+	_, err := verifyDIDOwnership(msg.DID, docWithSeq.Seq, docWithSeq.Document, msg.SigKeyID, msg.Signature)
 	if err != nil {
 		return err.Result()
 	}
@@ -55,23 +73,19 @@ func handleMsgDeleteDID(ctx sdk.Context, keeper Keeper, msg MsgDeleteDID) sdk.Re
 	return sdk.Result{}
 }
 
-func verifyDIDOwnership(ctx sdk.Context, keeper Keeper, did types.DID, keyID types.KeyID, sig []byte, data types.Signable) (types.Sequence, sdk.Error) {
-	docWithSeq := keeper.GetDIDDocument(ctx, did)
-	if docWithSeq.Empty() {
-		return 0, types.ErrDIDNotFound(did)
-	}
-
-	pubKey, ok := docWithSeq.Document.PubKeyByID(keyID)
+// verifyDIDOwnership verifies the DID ownership from a sig which is based on the data.
+// It fetches a public key from a doc using keyID. It also uses a seq to verifyDIDOwnership the sig.
+// If the verification is successful, it returns a new sequence. If not, it returns an error.
+func verifyDIDOwnership(data types.Signable, seq types.Sequence, doc types.DIDDocument, keyID types.KeyID, sig []byte) (types.Sequence, sdk.Error) {
+	pubKey, ok := doc.PubKeyByID(keyID)
 	if !ok {
 		return 0, types.ErrKeyIDNotFound(keyID)
 	}
-
 	pubKeySecp256k1, err := types.NewPubKeyFromBase58(pubKey.KeyBase58)
 	if err != nil {
 		return 0, types.ErrInvalidSecp256k1PublicKey(err)
 	}
-
-	newSeq, ok := types.Verify(sig, data, docWithSeq.Seq, pubKeySecp256k1)
+	newSeq, ok := types.Verify(sig, data, seq, pubKeySecp256k1)
 	if !ok {
 		return 0, types.ErrSigVerificationFailed()
 	}

--- a/x/did/keeper.go
+++ b/x/did/keeper.go
@@ -14,7 +14,6 @@ import (
 type Keeper interface {
 	Codec() *codec.Codec
 	SetDIDDocument(ctx sdk.Context, did types.DID, doc types.DIDDocumentWithSeq)
-	HasDID(ctx sdk.Context, did types.DID) bool
 	GetDIDDocument(ctx sdk.Context, did types.DID) types.DIDDocumentWithSeq
 	ListDIDs(ctx sdk.Context) []types.DID
 	DeleteDID(ctx sdk.Context, did types.DID)
@@ -45,11 +44,6 @@ func (k didKeeper) SetDIDDocument(ctx sdk.Context, did types.DID, doc types.DIDD
 	key := DIDDocumentKey(did)
 	bz := k.cdc.MustMarshalBinaryLengthPrefixed(doc)
 	store.Set(key, bz)
-}
-
-func (k didKeeper) HasDID(ctx sdk.Context, did types.DID) bool {
-	store := ctx.KVStore(k.storeKey)
-	return store.Has(DIDDocumentKey(did))
 }
 
 func (k didKeeper) GetDIDDocument(ctx sdk.Context, did types.DID) types.DIDDocumentWithSeq {

--- a/x/did/types/msgs.go
+++ b/x/did/types/msgs.go
@@ -14,12 +14,20 @@ var (
 type MsgCreateDID struct {
 	DID         DID            `json:"did"`
 	Document    DIDDocument    `json:"document"`
+	SigKeyID    KeyID          `json:"sig_key_id"`
+	Signature   []byte         `json:"signature"`
 	FromAddress sdk.AccAddress `json:"from_address"`
 }
 
 // NewMsgCreateDID is a constructor of MsgCreateDID.
-func NewMsgCreateDID(did DID, doc DIDDocument, fromAddr sdk.AccAddress) MsgCreateDID {
-	return MsgCreateDID{did, doc, fromAddr}
+func NewMsgCreateDID(did DID, doc DIDDocument, sigKeyID KeyID, sig []byte, fromAddr sdk.AccAddress) MsgCreateDID {
+	return MsgCreateDID{
+		DID:         did,
+		Document:    doc,
+		SigKeyID:    sigKeyID,
+		Signature:   sig,
+		FromAddress: fromAddr,
+	}
 }
 
 // Route returns the name of the module.
@@ -28,13 +36,16 @@ func (msg MsgCreateDID) Route() string { return RouterKey }
 // Type returns the name of the action.
 func (msg MsgCreateDID) Type() string { return "create_did" }
 
-// VaValidateBasic runs stateless checks on the message.
+// ValidateBasic runs stateless checks on the message.
 func (msg MsgCreateDID) ValidateBasic() sdk.Error {
 	if !msg.DID.Valid() {
 		return ErrInvalidDID(string(msg.DID))
 	}
 	if !msg.Document.Valid() {
 		return ErrInvalidDIDDocument(msg.Document)
+	}
+	if msg.Signature == nil || len(msg.Signature) == 0 {
+		return ErrInvalidSignature(msg.Signature)
 	}
 	if msg.FromAddress.Empty() {
 		return sdk.ErrInvalidAddress(msg.FromAddress.String())
@@ -63,7 +74,13 @@ type MsgUpdateDID struct {
 
 // NewMsgUpdateDID is a constructor of MsgUpdateDID.
 func NewMsgUpdateDID(did DID, doc DIDDocument, sigKeyID KeyID, sig []byte, fromAddr sdk.AccAddress) MsgUpdateDID {
-	return MsgUpdateDID{did, doc, sigKeyID, sig, fromAddr}
+	return MsgUpdateDID{
+		DID:         did,
+		Document:    doc,
+		SigKeyID:    sigKeyID,
+		Signature:   sig,
+		FromAddress: fromAddr,
+	}
 }
 
 // Route returns the name of the module.
@@ -72,7 +89,7 @@ func (msg MsgUpdateDID) Route() string { return RouterKey }
 // Type returns the name of the action.
 func (msg MsgUpdateDID) Type() string { return "update_did" }
 
-// VaValidateBasic runs stateless checks on the message.
+// ValidateBasic runs stateless checks on the message.
 func (msg MsgUpdateDID) ValidateBasic() sdk.Error {
 	if !msg.DID.Valid() {
 		return ErrInvalidDID(string(msg.DID))
@@ -108,8 +125,8 @@ type MsgDeleteDID struct {
 }
 
 // NewMsgDeleteDID is a constructor of MsgDeleteDID.
-func NewMsgDeleteDID(did DID, sigPubKeyID KeyID, sig []byte, fromAddr sdk.AccAddress) MsgDeleteDID {
-	return MsgDeleteDID{did, sigPubKeyID, sig, fromAddr}
+func NewMsgDeleteDID(did DID, sigKeyID KeyID, sig []byte, fromAddr sdk.AccAddress) MsgDeleteDID {
+	return MsgDeleteDID{did, sigKeyID, sig, fromAddr}
 }
 
 // Route returns the name of the module.

--- a/x/did/types/msgs_test.go
+++ b/x/did/types/msgs_test.go
@@ -1,0 +1,97 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/medibloc/panacea-core/x/did/types"
+
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func TestMsgCreateDID(t *testing.T) {
+	doc := newDIDDocument()
+	sig := []byte("my-sig")
+	fromAddr := getFromAddress(t)
+
+	msg := types.NewMsgCreateDID(doc.ID, doc, doc.PubKeys[0].ID, sig, fromAddr)
+	require.Equal(t, doc.ID, msg.DID)
+	require.Equal(t, doc, msg.Document)
+	require.Equal(t, doc.PubKeys[0].ID, msg.SigKeyID)
+	require.Equal(t, sig, msg.Signature)
+	require.Equal(t, fromAddr, msg.FromAddress)
+
+	require.Equal(t, types.RouterKey, msg.Route())
+	require.Equal(t, "create_did", msg.Type())
+	require.Nil(t, msg.ValidateBasic())
+	require.Equal(t, 1, len(msg.GetSigners()))
+	require.Equal(t, fromAddr, msg.GetSigners()[0])
+
+	require.Equal(t,
+		`{"type":"did/MsgCreateDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","document":{"authentication":["did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1"],"id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","publicKey":[{"id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"Secp256k1VerificationKey2018"}]},"from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","sig_key_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","signature":"bXktc2ln"}}`,
+		string(msg.GetSignBytes()),
+	)
+}
+
+func TestMsgUpdateDID(t *testing.T) {
+	doc := newDIDDocument()
+	sig := []byte("my-sig")
+	fromAddr := getFromAddress(t)
+
+	msg := types.NewMsgUpdateDID(doc.ID, doc, doc.PubKeys[0].ID, sig, fromAddr)
+	require.Equal(t, doc.ID, msg.DID)
+	require.Equal(t, doc, msg.Document)
+	require.Equal(t, doc.PubKeys[0].ID, msg.SigKeyID)
+	require.Equal(t, sig, msg.Signature)
+	require.Equal(t, fromAddr, msg.FromAddress)
+
+	require.Equal(t, types.RouterKey, msg.Route())
+	require.Equal(t, "update_did", msg.Type())
+	require.Nil(t, msg.ValidateBasic())
+	require.Equal(t, 1, len(msg.GetSigners()))
+	require.Equal(t, fromAddr, msg.GetSigners()[0])
+
+	require.Equal(t,
+		`{"type":"did/MsgUpdateDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","document":{"authentication":["did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1"],"id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","publicKey":[{"id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"Secp256k1VerificationKey2018"}]},"from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","sig_key_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","signature":"bXktc2ln"}}`,
+		string(msg.GetSignBytes()),
+	)
+}
+
+func TestDeleteDID(t *testing.T) {
+	doc := newDIDDocument()
+	sig := []byte("my-sig")
+	fromAddr := getFromAddress(t)
+
+	msg := types.NewMsgDeleteDID(doc.ID, doc.PubKeys[0].ID, sig, fromAddr)
+	require.Equal(t, doc.ID, msg.DID)
+	require.Equal(t, doc.PubKeys[0].ID, msg.SigKeyID)
+	require.Equal(t, sig, msg.Signature)
+	require.Equal(t, fromAddr, msg.FromAddress)
+
+	require.Equal(t, types.RouterKey, msg.Route())
+	require.Equal(t, "delete_did", msg.Type())
+	require.Nil(t, msg.ValidateBasic())
+	require.Equal(t, 1, len(msg.GetSigners()))
+	require.Equal(t, fromAddr, msg.GetSigners()[0])
+
+	require.Equal(t,
+		`{"type":"did/MsgDeleteDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","sig_key_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","signature":"bXktc2ln"}}`,
+		string(msg.GetSignBytes()),
+	)
+}
+
+func getFromAddress(t *testing.T) sdk.AccAddress {
+	sdk.GetConfig().SetBech32PrefixForAccount("panacea", "panaceapub")
+	fromAddr, err := sdk.AccAddressFromBech32("panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq")
+	require.NoError(t, err)
+	return fromAddr
+}
+
+func newDIDDocument() types.DIDDocument {
+	did, _ := types.NewDIDFrom("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
+	keyID := types.NewKeyID(did, "key1")
+	pubKeyBase58, _ := types.NewPubKeyFromBase58("qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b")
+	pubKey := types.NewPubKey(keyID, types.ES256K, pubKeyBase58)
+	return types.NewDIDDocument(did, pubKey)
+}


### PR DESCRIPTION
Based on #29 

Previously `MsgCreateDID` didn't have any signature and verification logic. It can cause that someone who doesn't know the DID private key can create a DID document.
To solve it, `MsgCreateDID` should have the signature, similar as `MsgUpdateDID`.