### PR TITLE
Deactivate DID instead of deleting it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,6 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Convert coverage.out into coverage.lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.2
-      with:
-        infile: artifacts/coverage.out
-        outfile: artifacts/coverage.lcov
-
-    - name: Report coverage.lcov as a comment
-      uses: romeovs/lcov-reporter-action@v0.2.16
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        lcov-file: artifacts/coverage.lcov
-
     - name: Publish coverage.html as an artifact
       uses: actions/upload-artifact@master
       with:

--- a/x/did/alias.go
+++ b/x/did/alias.go
@@ -14,7 +14,7 @@ var (
 )
 
 type (
-	MsgCreateDID = types.MsgCreateDID
-	MsgUpdateDID = types.MsgUpdateDID
-	MsgDeleteDID = types.MsgDeleteDID
+	MsgCreateDID     = types.MsgCreateDID
+	MsgUpdateDID     = types.MsgUpdateDID
+	MsgDeactivateDID = types.MsgDeactivateDID
 )

--- a/x/did/client/cli/query.go
+++ b/x/did/client/cli/query.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"errors"
-
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/medibloc/panacea-core/x/did"
@@ -50,7 +48,10 @@ func queryDIDDocumentWithSeq(cliCtx context.CLIContext, id types.DID) (types.DID
 	var doc types.DIDDocumentWithSeq
 	cliCtx.Codec.MustUnmarshalJSON(res, &doc)
 	if doc.Empty() {
-		return types.DIDDocumentWithSeq{}, errors.New("DID not found")
+		return types.DIDDocumentWithSeq{}, types.ErrDIDNotFound(id)
+	}
+	if doc.Deactivated() {
+		return types.DIDDocumentWithSeq{}, types.ErrDIDDeactivated(id)
 	}
 
 	return doc, nil

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -57,7 +57,7 @@ func GetCmdCreateDID(cdc *codec.Codec) *cobra.Command {
 			keyID := types.NewKeyID(did, "key1")
 			doc := types.NewDIDDocument(did, types.NewPubKey(keyID, types.ES256K, pubKey))
 
-			sig, err := types.Sign(doc, types.NewSequence(), privKey)
+			sig, err := types.Sign(doc, types.InitialSequence, privKey)
 			if err != nil {
 				return err
 			}
@@ -136,10 +136,10 @@ func GetCmdUpdateDID(cdc *codec.Codec) *cobra.Command {
 	return cmd
 }
 
-func GetCmdDeleteDID(cdc *codec.Codec) *cobra.Command {
+func GetCmdDeactivateDID(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete-did [did] [key-id]",
-		Short: "Delete a DID Document",
+		Use:   "deactivate-did [did] [key-id]",
+		Short: "Deactivate a DID Document",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
@@ -165,7 +165,7 @@ func GetCmdDeleteDID(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgDeleteDID(did, keyID, sig, cliCtx.GetFromAddress())
+			msg := types.NewMsgDeactivateDID(did, keyID, sig, cliCtx.GetFromAddress())
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/did/client/module_client.go
+++ b/x/did/client/module_client.go
@@ -43,7 +43,7 @@ func (mc ModuleClient) GetTxCmd() *cobra.Command {
 	didTxCmd.AddCommand(client.PostCommands(
 		didCmds.GetCmdCreateDID(mc.cdc),
 		didCmds.GetCmdUpdateDID(mc.cdc),
-		didCmds.GetCmdDeleteDID(mc.cdc),
+		didCmds.GetCmdDeactivateDID(mc.cdc),
 	)...)
 
 	return didTxCmd

--- a/x/did/genesis_test.go
+++ b/x/did/genesis_test.go
@@ -25,12 +25,14 @@ func TestGenesis(t *testing.T) {
 	keeper := newMockKeeper()
 	keeper.SetDIDDocument(ctx, did1, doc1)
 	keeper.SetDIDDocument(ctx, did2, doc2)
+	doc2Deactivated := doc2.Deactivate(doc2.Seq + 1)
+	keeper.SetDIDDocument(ctx, did2, doc2Deactivated)
 
 	// export a genesis
 	state := ExportGenesis(ctx, keeper)
 	require.Equal(t, 2, len(state.Documents))
 	require.Equal(t, doc1, state.Documents[newGenesisKey(did1)])
-	require.Equal(t, doc2, state.Documents[newGenesisKey(did2)])
+	require.Equal(t, doc2Deactivated, state.Documents[newGenesisKey(did2)])
 
 	// check if the exported genesis is valid
 	require.NoError(t, ValidateGenesis(state))
@@ -40,7 +42,7 @@ func TestGenesis(t *testing.T) {
 	InitGenesis(ctx, newK, state)
 	require.Equal(t, 2, len(newK.ListDIDs(ctx)))
 	require.Equal(t, doc1, newK.GetDIDDocument(ctx, did1))
-	require.Equal(t, doc2, newK.GetDIDDocument(ctx, did2))
+	require.Equal(t, doc2Deactivated, newK.GetDIDDocument(ctx, did2))
 }
 
 func newGenesisKey(did types.DID) string {

--- a/x/did/keeper.go
+++ b/x/did/keeper.go
@@ -16,7 +16,6 @@ type Keeper interface {
 	SetDIDDocument(ctx sdk.Context, did types.DID, doc types.DIDDocumentWithSeq)
 	GetDIDDocument(ctx sdk.Context, did types.DID) types.DIDDocumentWithSeq
 	ListDIDs(ctx sdk.Context) []types.DID
-	DeleteDID(ctx sdk.Context, did types.DID)
 }
 
 // didKeeper implements the Keeper interface
@@ -71,9 +70,4 @@ func (k didKeeper) ListDIDs(ctx sdk.Context) []types.DID {
 		dids = append(dids, did)
 	}
 	return dids
-}
-
-func (k didKeeper) DeleteDID(ctx sdk.Context, did types.DID) {
-	store := ctx.KVStore(k.storeKey)
-	store.Delete(DIDDocumentKey(did))
 }

--- a/x/did/types/auth.go
+++ b/x/did/types/auth.go
@@ -45,9 +45,7 @@ func mustGetSignBytesWithSeq(data Signable, seq Sequence) []byte {
 // Sequence is a preventative measure to distinguish replayed transactions (replay attack).
 type Sequence uint64
 
-func NewSequence() Sequence {
-	return 0
-}
+const InitialSequence = Sequence(0)
 
 func (s Sequence) next() Sequence {
 	return s + 1

--- a/x/did/types/auth_test.go
+++ b/x/did/types/auth_test.go
@@ -21,7 +21,7 @@ func TestMustGetSignBytesWithSeq(t *testing.T) {
 }
 
 func TestSequence(t *testing.T) {
-	seq := NewSequence()
+	seq := InitialSequence
 	require.Equal(t, Sequence(0), seq)
 
 	nextSeq := seq.next()

--- a/x/did/types/codec.go
+++ b/x/did/types/codec.go
@@ -14,5 +14,5 @@ func init() {
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgCreateDID{}, "did/MsgCreateDID", nil)
 	cdc.RegisterConcrete(MsgUpdateDID{}, "did/MsgUpdateDID", nil)
-	cdc.RegisterConcrete(MsgDeleteDID{}, "did/MsgDeleteDID", nil)
+	cdc.RegisterConcrete(MsgDeactivateDID{}, "did/MsgDeactivateDID", nil)
 }

--- a/x/did/types/did.go
+++ b/x/did/types/did.go
@@ -87,6 +87,10 @@ func NewDIDDocument(id DID, pubKey PubKey) DIDDocument {
 }
 
 func (doc DIDDocument) Valid() bool {
+	if doc.Empty() { // deactivated
+		return true
+	}
+
 	if !doc.ID.Valid() || doc.PubKeys == nil || doc.Authentications == nil {
 		return false
 	}
@@ -236,12 +240,25 @@ func NewDIDDocumentWithSeq(doc DIDDocument, seq Sequence) DIDDocumentWithSeq {
 	}
 }
 
+// Empty returns true if all members in DIDDocumentWithSeq are empty.
+// The empty struct means that the entity doesn't exist.
 func (d DIDDocumentWithSeq) Empty() bool {
-	return d.Document.Empty()
+	return d.Document.Empty() && d.Seq == InitialSequence
 }
 
 func (d DIDDocumentWithSeq) Valid() bool {
 	return d.Document.Valid()
+}
+
+// Deactivate creates a new DIDDocumentWithSeq with an empty DIDDocument (tombstone).
+// Note that it requires a new sequence.
+func (d DIDDocumentWithSeq) Deactivate(newSeq Sequence) DIDDocumentWithSeq {
+	return NewDIDDocumentWithSeq(DIDDocument{}, newSeq)
+}
+
+// Deactivated returns true if the DIDDocument has been activated.
+func (d DIDDocumentWithSeq) Deactivated() bool {
+	return d.Document.Empty() && d.Seq != InitialSequence
 }
 
 // NewPrivKeyFromBytes converts a byte slice into a Secp256k1 private key.

--- a/x/did/types/did_test.go
+++ b/x/did/types/did_test.go
@@ -114,16 +114,24 @@ func TestNewPubKey(t *testing.T) {
 }
 
 func TestDIDDocumentWithSeq_Empty(t *testing.T) {
-	require.False(t, NewDIDDocumentWithSeq(getValidDIDDocument(), NewSequence()).Empty())
+	require.False(t, NewDIDDocumentWithSeq(getValidDIDDocument(), InitialSequence).Empty())
 	require.True(t, DIDDocumentWithSeq{}.Empty())
 }
 
 func TestDIDDocumentWithSeq_Valid(t *testing.T) {
 	doc := getValidDIDDocument()
-	require.True(t, NewDIDDocumentWithSeq(doc, NewSequence()).Valid())
+	require.True(t, NewDIDDocumentWithSeq(doc, InitialSequence).Valid())
 	require.False(t, DIDDocumentWithSeq{
 		Document: DIDDocument{ID: "invalid_did"},
 	}.Valid())
+}
+
+func TestDIDDocumentWithSeq_Deactivate(t *testing.T) {
+	docWithSeq := NewDIDDocumentWithSeq(getValidDIDDocument(), InitialSequence)
+	deactivated := docWithSeq.Deactivate(InitialSequence + 1)
+	require.True(t, deactivated.Deactivated())
+	require.False(t, deactivated.Empty())
+	require.True(t, deactivated.Valid())
 }
 
 func getValidDIDDocument() DIDDocument {

--- a/x/did/types/errors.go
+++ b/x/did/types/errors.go
@@ -18,6 +18,7 @@ const (
 	CodeInvalidSecp256k1PublicKey sdk.CodeType = 109
 	CodeInvalidNetworkID          sdk.CodeType = 110
 	CodeInvalidDIDDocumentWithSeq sdk.CodeType = 111
+	CodeDIDDeactivated            sdk.CodeType = 112
 )
 
 func ErrDIDExists(did DID) sdk.Error {
@@ -49,7 +50,7 @@ func ErrKeyIDNotFound(id KeyID) sdk.Error {
 }
 
 func ErrSigVerificationFailed() sdk.Error {
-	return sdk.NewError(DefaultCodespace, CodeSigVerificationFailed, "Signature verification was failed")
+	return sdk.NewError(DefaultCodespace, CodeSigVerificationFailed, "DID signature verification was failed")
 }
 
 func ErrInvalidSecp256k1PublicKey(err error) sdk.Error {
@@ -62,4 +63,8 @@ func ErrInvalidNetworkID(id string) sdk.Error {
 
 func ErrInvalidDIDDocumentWithSeq(doc DIDDocumentWithSeq) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidDIDDocumentWithSeq, "Invalid DIDDocumentWithSeq: %v", doc)
+}
+
+func ErrDIDDeactivated(did DID) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeDIDDeactivated, "DID was already deactivated: %v", did)
 }

--- a/x/did/types/msgs.go
+++ b/x/did/types/msgs.go
@@ -7,7 +7,7 @@ import (
 var (
 	_ sdk.Msg = &MsgCreateDID{}
 	_ sdk.Msg = &MsgUpdateDID{}
-	_ sdk.Msg = &MsgDeleteDID{}
+	_ sdk.Msg = &MsgDeactivateDID{}
 )
 
 // MsgCreateDID defines a CreateDID message.
@@ -116,27 +116,27 @@ func (msg MsgUpdateDID) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.FromAddress}
 }
 
-// MsgDeleteDID defines a UpdateDID message.
-type MsgDeleteDID struct {
+// MsgDeactivateDID defines a UpdateDID message.
+type MsgDeactivateDID struct {
 	DID         DID            `json:"did"`
 	SigKeyID    KeyID          `json:"sig_key_id"`
 	Signature   []byte         `json:"signature"`
 	FromAddress sdk.AccAddress `json:"from_address"`
 }
 
-// NewMsgDeleteDID is a constructor of MsgDeleteDID.
-func NewMsgDeleteDID(did DID, sigKeyID KeyID, sig []byte, fromAddr sdk.AccAddress) MsgDeleteDID {
-	return MsgDeleteDID{did, sigKeyID, sig, fromAddr}
+// NewMsgDeactivateDID is a constructor of MsgDeactivateDID.
+func NewMsgDeactivateDID(did DID, sigKeyID KeyID, sig []byte, fromAddr sdk.AccAddress) MsgDeactivateDID {
+	return MsgDeactivateDID{did, sigKeyID, sig, fromAddr}
 }
 
 // Route returns the name of the module.
-func (msg MsgDeleteDID) Route() string { return RouterKey }
+func (msg MsgDeactivateDID) Route() string { return RouterKey }
 
 // Type returns the name of the action.
-func (msg MsgDeleteDID) Type() string { return "delete_did" }
+func (msg MsgDeactivateDID) Type() string { return "deactivate_did" }
 
 // VaValidateBasic runs stateless checks on the message.
-func (msg MsgDeleteDID) ValidateBasic() sdk.Error {
+func (msg MsgDeactivateDID) ValidateBasic() sdk.Error {
 	if !msg.DID.Valid() {
 		return ErrInvalidDID(string(msg.DID))
 	}
@@ -150,11 +150,11 @@ func (msg MsgDeleteDID) ValidateBasic() sdk.Error {
 }
 
 // GetSignBytes returns the canonical byte representation of the message. Used to generate a signature.
-func (msg MsgDeleteDID) GetSignBytes() []byte {
+func (msg MsgDeactivateDID) GetSignBytes() []byte {
 	return sdk.MustSortJSON(didCodec.MustMarshalJSON(msg))
 }
 
 // GetSigners return the addresses of signers that must sign.
-func (msg MsgDeleteDID) GetSigners() []sdk.AccAddress {
+func (msg MsgDeactivateDID) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.FromAddress}
 }

--- a/x/did/types/msgs_test.go
+++ b/x/did/types/msgs_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/medibloc/panacea-core/x/did/types"
@@ -9,6 +10,11 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
+
+func TestMain(m *testing.M) {
+	sdk.GetConfig().SetBech32PrefixForAccount("panacea", "panaceapub")
+	os.Exit(m.Run())
+}
 
 func TestMsgCreateDID(t *testing.T) {
 	doc := newDIDDocument()
@@ -58,31 +64,30 @@ func TestMsgUpdateDID(t *testing.T) {
 	)
 }
 
-func TestDeleteDID(t *testing.T) {
+func TestDeactivateDID(t *testing.T) {
 	doc := newDIDDocument()
 	sig := []byte("my-sig")
 	fromAddr := getFromAddress(t)
 
-	msg := types.NewMsgDeleteDID(doc.ID, doc.PubKeys[0].ID, sig, fromAddr)
+	msg := types.NewMsgDeactivateDID(doc.ID, doc.PubKeys[0].ID, sig, fromAddr)
 	require.Equal(t, doc.ID, msg.DID)
 	require.Equal(t, doc.PubKeys[0].ID, msg.SigKeyID)
 	require.Equal(t, sig, msg.Signature)
 	require.Equal(t, fromAddr, msg.FromAddress)
 
 	require.Equal(t, types.RouterKey, msg.Route())
-	require.Equal(t, "delete_did", msg.Type())
+	require.Equal(t, "deactivate_did", msg.Type())
 	require.Nil(t, msg.ValidateBasic())
 	require.Equal(t, 1, len(msg.GetSigners()))
 	require.Equal(t, fromAddr, msg.GetSigners()[0])
 
 	require.Equal(t,
-		`{"type":"did/MsgDeleteDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","sig_key_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","signature":"bXktc2ln"}}`,
+		`{"type":"did/MsgDeactivateDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","sig_key_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","signature":"bXktc2ln"}}`,
 		string(msg.GetSignBytes()),
 	)
 }
 
 func getFromAddress(t *testing.T) sdk.AccAddress {
-	sdk.GetConfig().SetBech32PrefixForAccount("panacea", "panaceapub")
 	fromAddr, err := sdk.AccAddressFromBech32("panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq")
 	require.NoError(t, err)
 	return fromAddr


### PR DESCRIPTION
Based on #34 

According to the [DID spec](https://www.w3.org/TR/did-core/#did-syntax):
```
A DID is expected to be persistent and immutable. That is, a DID is bound exclusively and permanently to its one and only subject. Even after a DID is deactivated, it is intended that it never be repurposed.
```
DID shouldn't be deleted from Keeper. It should be just deactivated, so that anyone cannot recreate it.

This topic also has been discussed in [#29](https://github.com/medibloc/panacea-core/pull/29#issuecomment-684121150). 