### PR TITLE
Check if the prefix of the DID KeyID matches with the DID

### DIFF
--- a/x/did/client/cli/query.go
+++ b/x/did/client/cli/query.go
@@ -19,7 +19,7 @@ func GetCmdQueryDID(cdc *codec.Codec) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			id, err := types.NewDIDFrom(args[0])
+			id, err := types.ParseDID(args[0])
 			if err != nil {
 				return err
 			}

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -98,11 +98,11 @@ func GetCmdUpdateDID(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
 
-			did, err := types.NewDIDFrom(args[0])
+			did, err := types.ParseDID(args[0])
 			if err != nil {
 				return err
 			}
-			keyID, err := types.NewKeyIDFrom(args[1], did)
+			keyID, err := types.ParseKeyID(args[1], did)
 			if err != nil {
 				return err
 			}
@@ -141,11 +141,11 @@ func GetCmdDeactivateDID(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
 
-			did, err := types.NewDIDFrom(args[0])
+			did, err := types.ParseDID(args[0])
 			if err != nil {
 				return err
 			}
-			keyID, err := types.NewKeyIDFrom(args[1], did)
+			keyID, err := types.ParseKeyID(args[1], did)
 			if err != nil {
 				return err
 			}

--- a/x/did/client/cli/tx.go
+++ b/x/did/client/cli/tx.go
@@ -102,7 +102,7 @@ func GetCmdUpdateDID(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			keyID, err := types.NewKeyIDFrom(args[1])
+			keyID, err := types.NewKeyIDFrom(args[1], did)
 			if err != nil {
 				return err
 			}
@@ -145,7 +145,7 @@ func GetCmdDeactivateDID(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			keyID, err := types.NewKeyIDFrom(args[1])
+			keyID, err := types.NewKeyIDFrom(args[1], did)
 			if err != nil {
 				return err
 			}

--- a/x/did/types/did.go
+++ b/x/did/types/did.go
@@ -23,7 +23,7 @@ func NewDID(networkID NetworkID, pubKey crypto.PubKey, keyType KeyType) DID {
 	return DID(fmt.Sprintf("did:%s:%s:%s", DIDMethod, networkID, idStr))
 }
 
-func NewDIDFrom(str string) (DID, error) {
+func ParseDID(str string) (DID, error) {
 	did := DID(str)
 	if !did.Valid() {
 		return "", ErrInvalidDID(str)
@@ -146,7 +146,7 @@ func NewKeyID(did DID, name string) KeyID {
 	return KeyID(fmt.Sprintf("%v#%s", did, name))
 }
 
-func NewKeyIDFrom(id string, did DID) (KeyID, error) {
+func ParseKeyID(id string, did DID) (KeyID, error) {
 	keyID := KeyID(id)
 	if !keyID.Valid(did) {
 		return "", ErrInvalidKeyID(id)

--- a/x/did/types/did.go
+++ b/x/did/types/did.go
@@ -96,13 +96,13 @@ func (doc DIDDocument) Valid() bool {
 	}
 
 	for _, pubKey := range doc.PubKeys {
-		if !pubKey.Valid() {
+		if !pubKey.Valid(doc.ID) {
 			return false
 		}
 	}
 
 	for _, auth := range doc.Authentications {
-		if !auth.Valid() {
+		if !auth.Valid(doc.ID) {
 			return false
 		}
 		if _, ok := doc.PubKeyByID(KeyID(auth)); !ok {
@@ -146,16 +146,16 @@ func NewKeyID(did DID, name string) KeyID {
 	return KeyID(fmt.Sprintf("%v#%s", did, name))
 }
 
-func NewKeyIDFrom(id string) (KeyID, error) {
+func NewKeyIDFrom(id string, did DID) (KeyID, error) {
 	keyID := KeyID(id)
-	if !keyID.Valid() {
+	if !keyID.Valid(did) {
 		return "", ErrInvalidKeyID(id)
 	}
 	return keyID, nil
 }
 
-func (id KeyID) Valid() bool {
-	pattern := fmt.Sprintf("^%s#.+$", didRegex()) //TODO: exclude whitespaces
+func (id KeyID) Valid(did DID) bool {
+	pattern := fmt.Sprintf("^%v#.+$", did) //TODO: exclude whitespaces
 	matched, _ := regexp.MatchString(pattern, string(id))
 	return matched
 }
@@ -209,8 +209,8 @@ func encodePubKeyES256K(key crypto.PubKey, truncateLen int) string {
 	return base58.Encode(k)
 }
 
-func (pk PubKey) Valid() bool {
-	if !pk.ID.Valid() || !pk.Type.Valid() {
+func (pk PubKey) Valid(did DID) bool {
+	if !pk.ID.Valid(did) || !pk.Type.Valid() {
 		return false
 	}
 
@@ -222,8 +222,8 @@ func (pk PubKey) Valid() bool {
 // TODO: to be extended
 type Authentication KeyID
 
-func (a Authentication) Valid() bool {
-	return KeyID(a).Valid()
+func (a Authentication) Valid(did DID) bool {
+	return KeyID(a).Valid(did)
 }
 
 // DIDDocumentWithSeq is for storing a Sequence along with a DIDDocument.

--- a/x/did/types/did.go
+++ b/x/did/types/did.go
@@ -155,7 +155,7 @@ func NewKeyIDFrom(id string, did DID) (KeyID, error) {
 }
 
 func (id KeyID) Valid(did DID) bool {
-	pattern := fmt.Sprintf("^%v#.+$", did) //TODO: exclude whitespaces
+	pattern := fmt.Sprintf(`^%v#\S+$`, did)
 	matched, _ := regexp.MatchString(pattern, string(id))
 	return matched
 }

--- a/x/did/types/did_test.go
+++ b/x/did/types/did_test.go
@@ -96,7 +96,18 @@ func TestNewKeyID(t *testing.T) {
 }
 
 func TestKeyID_Valid(t *testing.T) {
+	// normal
 	require.True(t, KeyID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1").Valid("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"))
+
+	// if suffix has whitespaces
+	require.False(t, KeyID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP# key1").Valid("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"))
+	require.False(t, KeyID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1 ").Valid("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"))
+
+	// if suffix is empty
+	require.False(t, KeyID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#").Valid("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"))
+	require.False(t, KeyID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP").Valid("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"))
+
+	// if prefix (DID) is invalid
 	require.False(t, KeyID("invalid#key1").Valid("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"))
 	require.False(t, KeyID("did:panacea:mainnet:KS5zGZt66Me8MCctZBYrP#key1").Valid("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"))
 }

--- a/x/did/types/did_test.go
+++ b/x/did/types/did_test.go
@@ -21,14 +21,14 @@ func TestNewDID(t *testing.T) {
 	require.Regexp(t, regex, did)
 }
 
-func TestNewDIDFrom(t *testing.T) {
+func TestParseDID(t *testing.T) {
 	str := "did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"
-	did, err := NewDIDFrom(str)
+	did, err := ParseDID(str)
 	require.NoError(t, err)
 	require.EqualValues(t, str, did)
 
 	str = "did:panacea:t1estnet:KS5zGZt66Me8MCctZBYrP"
-	_, err = NewDIDFrom(str)
+	_, err = ParseDID(str)
 	require.EqualError(t, err, ErrInvalidDID(str).Error())
 }
 
@@ -90,7 +90,7 @@ func TestNewKeyID(t *testing.T) {
 	require.True(t, id.Valid(did))
 	require.EqualValues(t, expectedID, id)
 
-	id, err := NewKeyIDFrom(expectedID, did)
+	id, err := ParseKeyID(expectedID, did)
 	require.NoError(t, err)
 	require.EqualValues(t, expectedID, id)
 }

--- a/x/did/types/did_test.go
+++ b/x/did/types/did_test.go
@@ -87,15 +87,18 @@ func TestNewKeyID(t *testing.T) {
 	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
 	expectedID := fmt.Sprintf("%s#key1", did)
 	id := NewKeyID(did, "key1")
-	require.True(t, id.Valid())
+	require.True(t, id.Valid(did))
 	require.EqualValues(t, expectedID, id)
 
-	id, err := NewKeyIDFrom(expectedID)
+	id, err := NewKeyIDFrom(expectedID, did)
 	require.NoError(t, err)
 	require.EqualValues(t, expectedID, id)
+}
 
-	_, err = NewKeyIDFrom("invalid_id")
-	require.Error(t, err, ErrInvalidKeyID("invalid_id"))
+func TestKeyID_Valid(t *testing.T) {
+	require.True(t, KeyID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1").Valid("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"))
+	require.False(t, KeyID("invalid#key1").Valid("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"))
+	require.False(t, KeyID("did:panacea:mainnet:KS5zGZt66Me8MCctZBYrP#key1").Valid("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP"))
 }
 
 func TestKeyType_Valid(t *testing.T) {
@@ -107,7 +110,7 @@ func TestNewPubKey(t *testing.T) {
 	did := DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
 	pubKey := secp256k1.GenPrivKey().PubKey()
 	pub := NewPubKey(NewKeyID(did, "key1"), ES256K, pubKey)
-	require.True(t, pub.Valid())
+	require.True(t, pub.Valid(did))
 
 	expected := pubKey.(secp256k1.PubKeySecp256k1)
 	require.Equal(t, expected[:], base58.Decode(pub.KeyBase58))

--- a/x/did/types/msgs_test.go
+++ b/x/did/types/msgs_test.go
@@ -94,7 +94,7 @@ func getFromAddress(t *testing.T) sdk.AccAddress {
 }
 
 func newDIDDocument() types.DIDDocument {
-	did, _ := types.NewDIDFrom("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
+	did, _ := types.ParseDID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
 	keyID := types.NewKeyID(did, "key1")
 	pubKeyBase58, _ := types.NewPubKeyFromBase58("qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b")
 	pubKey := types.NewPubKey(keyID, types.ES256K, pubKeyBase58)


### PR DESCRIPTION
The format of DID KeyID is:
```
did#name
```
like `did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1`.

Here, the prefix (the DID part) must match with the DID (eg. `did:panacea:testnet:KS5zGZt66Me8MCctZBYrP`).

Also, the suffix (`#key1`) must not have whitespaces.