### PR TITLE
Use DID `verificationMethod` terminology and Add the method `controller`

### DIFF
--- a/docs/did.md
+++ b/docs/did.md
@@ -78,10 +78,11 @@ The details are described below.
 {
     "@context": "https://www.w3.org/ns/did/v1",
     "id": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
-    "publicKey": [
+    "verificationMethod": [
         {
             "id": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff#key1",
             "type": "Secp256k1VerificationKey2018",
+            "controller": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
             "publicKeyBase58": "dBuN4i7dqwCLzSX7GHBLsfUoXw5RmWQ3DwQ9Ee4bfh5Y"
         }
     ],
@@ -91,7 +92,10 @@ The details are described below.
 }
 ```
 
-The Key IDs in the `authentication` are references to one of public keys specified in the `publicKey`.
+Currently, the `controller` in the `verificationMethod` must be equal to the [DID subject](https://www.w3.org/TR/2020/WD-did-core-20200907/#dfn-did-subjects).
+It would be extended later.
+
+The Key IDs in the `authentication` are references to one of public keys specified in the `verificationMethod`.
 The spec of the `authentication` would be extended in the future.
 
 The Panacea DID Document doesn't contain the `service` field currently. It would be extended soon.
@@ -106,14 +110,15 @@ To create a DID Document in Panacea, the following transaction should be submitt
 {
     "type": "did/MsgCreateDID",
     "value": {
-    "did": "did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh",
+        "did": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
         "document": {
             "@context": "https://www.w3.org/ns/did/v1",
             "id": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
-            "publicKey": [
+            "verificationMethod": [
                 {
                     "id": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff#key1",
                     "type": "Secp256k1VerificationKey2018",
+                    "controller": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
                     "publicKeyBase58": "dBuN4i7dqwCLzSX7GHBLsfUoXw5RmWQ3DwQ9Ee4bfh5Y"
                 }
             ],
@@ -166,10 +171,11 @@ If the DID exists (not deactivated yet), the result is:
     "document": {
         "@context": "https://www.w3.org/ns/did/v1",
         "id": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
-        "publicKey": [
+        "verificationMethod": [
             {
                 "id": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff#key1",
                 "type": "Secp256k1VerificationKey2018",
+                "controller": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
                 "publicKeyBase58": "dBuN4i7dqwCLzSX7GHBLsfUoXw5RmWQ3DwQ9Ee4bfh5Y"
             }
         ],
@@ -188,24 +194,26 @@ It must be included in the subsequent transaction (update/deactivate) for preven
 
 Only the DID owner can replace the DID Document using the following transaction.
 
-This example is for adding a new public key to the `publicKey` and adding a dedicated public key to the `authentication`.
+This example is for adding a new public key to the `verificationMethod` and adding a dedicated public key to the `authentication`.
 ```json
 {
     "type": "did/MsgUpdateDID",
     "value": {
-        "did": "did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh",
+        "did": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
         "document": {
             "@context": "https://www.w3.org/ns/did/v1",
             "id": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
-            "publicKey": [
+            "verificationMethod": [
                 {
                     "id": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff#key1",
                     "type": "Secp256k1VerificationKey2018",
+                    "controller": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
                     "publicKeyBase58": "dBuN4i7dqwCLzSX7GHBLsfUoXw5RmWQ3DwQ9Ee4bfh5Y"
                 },
                 {
                     "id": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff#key2",
                     "type": "Secp256k1VerificationKey2018",
+                    "controller": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
                     "publicKeyBase58": "2BjcxuwijyE1om4991ANiFrwZJ3Ev5YYX9KiPKgaHmGsi"
                 }
             ],
@@ -214,6 +222,7 @@ This example is for adding a new public key to the `publicKey` and adding a dedi
                 {
                     "id": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff#key3",
                     "type": "Secp256k1VerificationKey2018",
+                    "controller": "did:panacea:mainnet:G3UzSnRRsyApppuHVuaff",
                     "publicKeyBase58": "yE1om4991ANiFrwZJ3Ev5YYX9KiPKgaHmGsi2Bjcxuwij"
                 }
             ]

--- a/x/did/client/cli/tx_test.go
+++ b/x/did/client/cli/tx_test.go
@@ -33,9 +33,9 @@ func TestNewMsgCreateDID(t *testing.T) {
 	msg, err := newMsgCreateDID(getCliContext(t), "testnet", privKey)
 	require.NoError(t, err)
 
-	// check if pubKey is correct
-	pub, _ := msg.Document.PubKeyByID(msg.SigKeyID)
-	pubKey, _ := types.NewPubKeyFromBase58(pub.KeyBase58)
+	// check if veriMethod is correct
+	veriMethod, _ := msg.Document.VeriMethodByID(msg.VeriMethodID)
+	pubKey, _ := types.NewPubKeyFromBase58(veriMethod.PubKeyBase58)
 	require.Equal(t, privKey.PubKey(), pubKey)
 
 	// check if the signature can be verifiable with the initial sequence
@@ -102,14 +102,14 @@ func TestReadBIP39ParamsFrom_InvalidMnemonic(t *testing.T) {
 
 // Check if the private key is stored and loaded correctly by the password specified.
 func TestSaveAndGetPrivKeyFromKeyStore(t *testing.T) {
-	keyID := types.KeyID("key1")
+	veriMethodID := types.VeriMethodID("key1")
 	privKey, _ := crypto.GenSecp256k1PrivKey("", "")
 
 	reader := bufio.NewReader(strings.NewReader("mypassword1\nmypassword1\n"))
-	require.NoError(t, savePrivKeyToKeyStore(keyID, privKey, reader))
+	require.NoError(t, savePrivKeyToKeyStore(veriMethodID, privKey, reader))
 
 	reader = bufio.NewReader(strings.NewReader("mypassword1\n"))
-	privKeyLoaded, err := getPrivKeyFromKeyStore(keyID, reader)
+	privKeyLoaded, err := getPrivKeyFromKeyStore(veriMethodID, reader)
 	require.NoError(t, err)
 	require.Equal(t, privKey, privKeyLoaded)
 }

--- a/x/did/handler_test.go
+++ b/x/did/handler_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestHandleMsgCreateDID(t *testing.T) {
-	did, doc, privKey, keyID, keeper := ctx()
-	msg := newMsgCreateDID(t, doc.Document, keyID, privKey)
+	did, doc, privKey, veriMethodID, keeper := ctx()
+	msg := newMsgCreateDID(t, doc.Document, veriMethodID, privKey)
 
 	res := handleMsgCreateDID(sdk.Context{}, keeper, msg)
 	require.True(t, res.IsOK())
@@ -23,8 +23,8 @@ func TestHandleMsgCreateDID(t *testing.T) {
 }
 
 func TestHandleMsgCreateDID_Exists(t *testing.T) {
-	did, doc, privKey, keyID, keeper := ctx()
-	msg := newMsgCreateDID(t, doc.Document, keyID, privKey)
+	did, doc, privKey, veriMethodID, keeper := ctx()
+	msg := newMsgCreateDID(t, doc.Document, veriMethodID, privKey)
 
 	// create
 	handleMsgCreateDID(sdk.Context{}, keeper, msg)
@@ -35,12 +35,12 @@ func TestHandleMsgCreateDID_Exists(t *testing.T) {
 }
 
 func TestHandleMsgCreateDID_Deactivated(t *testing.T) {
-	did, doc, privKey, keyID, keeper := ctx()
-	msg := newMsgCreateDID(t, doc.Document, keyID, privKey)
+	did, doc, privKey, veriMethodID, keeper := ctx()
+	msg := newMsgCreateDID(t, doc.Document, veriMethodID, privKey)
 
 	// create and deactivate
 	handleMsgCreateDID(sdk.Context{}, keeper, msg)
-	handleMsgDeactivateDID(sdk.Context{}, keeper, newMsgDeactivateDID(t, did, keyID, privKey, types.InitialSequence))
+	handleMsgDeactivateDID(sdk.Context{}, keeper, newMsgDeactivateDID(t, did, veriMethodID, privKey, types.InitialSequence))
 
 	// create once again
 	res := handleMsgCreateDID(sdk.Context{}, keeper, msg)
@@ -48,32 +48,33 @@ func TestHandleMsgCreateDID_Deactivated(t *testing.T) {
 }
 
 func TestHandleMsgCreateDID_SigVerificationFailed(t *testing.T) {
-	did, doc, privKey, keyID, keeper := ctx()
+	did, doc, privKey, veriMethodID, keeper := ctx()
 	sig, _ := types.Sign(doc.Document, types.InitialSequence, privKey)
 	sig[0] += 1 // pollute the signature
 
 	res := handleMsgCreateDID(sdk.Context{}, keeper, types.NewMsgCreateDID(
-		did, doc.Document, keyID, sig, sdk.AccAddress{},
+		did, doc.Document, veriMethodID, sig, sdk.AccAddress{},
 	))
 	require.Equal(t, types.ErrSigVerificationFailed().Result(), res)
 }
 
 func TestHandleMsgUpdateDID(t *testing.T) {
-	did, origDoc, privKey, keyID, keeper := ctx()
+	did, origDoc, privKey, veriMethodID, keeper := ctx()
 
 	// create
-	handleMsgCreateDID(sdk.Context{}, keeper, newMsgCreateDID(t, origDoc.Document, keyID, privKey))
+	handleMsgCreateDID(sdk.Context{}, keeper, newMsgCreateDID(t, origDoc.Document, veriMethodID, privKey))
 
 	// prepare a new doc
 	newDoc := origDoc.Document
-	newDoc.PubKeys = append(newDoc.PubKeys, types.NewPubKey(
-		types.NewKeyID(did, "key2"),
+	newDoc.VeriMethods = append(newDoc.VeriMethods, types.NewVeriMethod(
+		types.NewVeriMethodID(did, "key2"),
 		types.ES256K,
+		did,
 		secp256k1.GenPrivKey().PubKey(),
 	))
 
 	// call
-	msg := newMsgUpdateDID(t, newDoc, keyID, privKey, origDoc.Seq)
+	msg := newMsgUpdateDID(t, newDoc, veriMethodID, privKey, origDoc.Seq)
 	res := handleMsgUpdateDID(sdk.Context{}, keeper, msg)
 	require.True(t, res.IsOK())
 	require.Equal(t, 1, len(keeper.ListDIDs(sdk.Context{})))
@@ -88,32 +89,32 @@ func TestHandleMsgUpdateDID(t *testing.T) {
 }
 
 func TestHandleMsgUpdateDID_DIDNotFound(t *testing.T) {
-	did, origDoc, privKey, keyID, keeper := ctx()
+	did, origDoc, privKey, veriMethodID, keeper := ctx()
 
 	// update without creation
-	res := handleMsgUpdateDID(sdk.Context{}, keeper, newMsgUpdateDID(t, origDoc.Document, keyID, privKey, origDoc.Seq))
+	res := handleMsgUpdateDID(sdk.Context{}, keeper, newMsgUpdateDID(t, origDoc.Document, veriMethodID, privKey, origDoc.Seq))
 	require.Equal(t, types.ErrDIDNotFound(did).Result(), res)
 }
 
 func TestHandleMsgUpdateDID_DIDDeactivated(t *testing.T) {
-	did, origDoc, privKey, keyID, keeper := ctx()
-	handleMsgCreateDID(sdk.Context{}, keeper, newMsgCreateDID(t, origDoc.Document, keyID, privKey))
+	did, origDoc, privKey, veriMethodID, keeper := ctx()
+	handleMsgCreateDID(sdk.Context{}, keeper, newMsgCreateDID(t, origDoc.Document, veriMethodID, privKey))
 
 	// deactivate
-	deactivateMsg := newMsgDeactivateDID(t, did, keyID, privKey, origDoc.Seq)
+	deactivateMsg := newMsgDeactivateDID(t, did, veriMethodID, privKey, origDoc.Seq)
 	require.True(t, handleMsgDeactivateDID(sdk.Context{}, keeper, deactivateMsg).IsOK())
 
 	// update
-	res := handleMsgUpdateDID(sdk.Context{}, keeper, newMsgUpdateDID(t, origDoc.Document, keyID, privKey, origDoc.Seq))
+	res := handleMsgUpdateDID(sdk.Context{}, keeper, newMsgUpdateDID(t, origDoc.Document, veriMethodID, privKey, origDoc.Seq))
 	require.Equal(t, types.ErrDIDDeactivated(did).Result(), res)
 }
 
 func TestHandleMsgDeactivateDID(t *testing.T) {
-	did, doc, privKey, keyID, keeper := ctx()
-	handleMsgCreateDID(sdk.Context{}, keeper, newMsgCreateDID(t, doc.Document, keyID, privKey))
+	did, doc, privKey, veriMethodID, keeper := ctx()
+	handleMsgCreateDID(sdk.Context{}, keeper, newMsgCreateDID(t, doc.Document, veriMethodID, privKey))
 
 	// deactivate
-	msg := newMsgDeactivateDID(t, did, keyID, privKey, types.InitialSequence)
+	msg := newMsgDeactivateDID(t, did, veriMethodID, privKey, types.InitialSequence)
 	res := handleMsgDeactivateDID(sdk.Context{}, keeper, msg)
 	require.True(t, res.IsOK())
 
@@ -125,20 +126,20 @@ func TestHandleMsgDeactivateDID(t *testing.T) {
 }
 
 func TestHandleMsgDeactivateDID_DIDNotFound(t *testing.T) {
-	did, _, privKey, keyID, keeper := ctx()
+	did, _, privKey, veriMethodID, keeper := ctx()
 
 	// deactivate without creation
-	msg := newMsgDeactivateDID(t, did, keyID, privKey, types.InitialSequence)
+	msg := newMsgDeactivateDID(t, did, veriMethodID, privKey, types.InitialSequence)
 	res := handleMsgDeactivateDID(sdk.Context{}, keeper, msg)
 	require.Equal(t, types.ErrDIDNotFound(did).Result(), res)
 }
 
 func TestHandleMsgDeactivateDID_DIDDeactivated(t *testing.T) {
-	did, doc, privKey, keyID, keeper := ctx()
-	handleMsgCreateDID(sdk.Context{}, keeper, newMsgCreateDID(t, doc.Document, keyID, privKey))
+	did, doc, privKey, veriMethodID, keeper := ctx()
+	handleMsgCreateDID(sdk.Context{}, keeper, newMsgCreateDID(t, doc.Document, veriMethodID, privKey))
 
 	// deactivate
-	msg := newMsgDeactivateDID(t, did, keyID, privKey, types.InitialSequence)
+	msg := newMsgDeactivateDID(t, did, veriMethodID, privKey, types.InitialSequence)
 	handleMsgDeactivateDID(sdk.Context{}, keeper, msg)
 
 	// one more time
@@ -147,43 +148,43 @@ func TestHandleMsgDeactivateDID_DIDDeactivated(t *testing.T) {
 }
 
 func TestHandleMsgDeactivateDID_SigVerificationFailed(t *testing.T) {
-	did, doc, privKey, keyID, keeper := ctx()
-	handleMsgCreateDID(sdk.Context{}, keeper, newMsgCreateDID(t, doc.Document, keyID, privKey))
+	did, doc, privKey, veriMethodID, keeper := ctx()
+	handleMsgCreateDID(sdk.Context{}, keeper, newMsgCreateDID(t, doc.Document, veriMethodID, privKey))
 
 	sig, _ := types.Sign(did, doc.Seq, privKey)
 	sig[0] += 1 // pollute the signature
 
-	msg := types.NewMsgDeactivateDID(did, keyID, sig, sdk.AccAddress{})
+	msg := types.NewMsgDeactivateDID(did, veriMethodID, sig, sdk.AccAddress{})
 	res := handleMsgDeactivateDID(sdk.Context{}, keeper, msg)
 	require.Equal(t, types.ErrSigVerificationFailed().Result(), res)
 }
 
 func TestVerifyDIDOwnership(t *testing.T) {
-	_, doc, privKey, keyID, _ := ctx()
+	_, doc, privKey, veriMethodID, _ := ctx()
 	data := any("random string")
 	sig, _ := types.Sign(data, doc.Seq, privKey)
 
-	newSeq, err := verifyDIDOwnership(data, doc.Seq, doc.Document, keyID, sig)
+	newSeq, err := verifyDIDOwnership(data, doc.Seq, doc.Document, veriMethodID, sig)
 	require.NoError(t, err)
 	require.Equal(t, doc.Seq+1, newSeq)
 }
 
-func TestVerifyDIDOwnership_KeyIDNotFound(t *testing.T) {
-	_, doc, privKey, keyID, _ := ctx()
+func TestVerifyDIDOwnership_VeriMethodIDNotFound(t *testing.T) {
+	_, doc, privKey, veriMethodID, _ := ctx()
 	data := any("random string")
 	sig, _ := types.Sign(data, doc.Seq, privKey)
 
-	dummyKeyID := keyID + "dummy"
-	_, err := verifyDIDOwnership(data, doc.Seq, doc.Document, dummyKeyID, sig)
-	require.EqualError(t, err, types.ErrKeyIDNotFound(dummyKeyID).Error())
+	dummyVeriMethodID := veriMethodID + "dummy"
+	_, err := verifyDIDOwnership(data, doc.Seq, doc.Document, dummyVeriMethodID, sig)
+	require.EqualError(t, err, types.ErrVeriMethodIDNotFound(dummyVeriMethodID).Error())
 }
 
 func TestVerifyDIDOwnership_SigVerificationFailed(t *testing.T) {
-	_, doc, privKey, keyID, _ := ctx()
+	_, doc, privKey, veriMethodID, _ := ctx()
 	data := any("random string")
 	sig, _ := types.Sign(data, doc.Seq+11234, privKey)
 
-	_, err := verifyDIDOwnership(data, doc.Seq, doc.Document, keyID, sig)
+	_, err := verifyDIDOwnership(data, doc.Seq, doc.Document, veriMethodID, sig)
 	require.EqualError(t, err, types.ErrSigVerificationFailed().Error())
 }
 
@@ -223,34 +224,34 @@ func (k mockKeeper) ListDIDs(ctx sdk.Context) []types.DID {
 	return dids
 }
 
-func ctx() (types.DID, types.DIDDocumentWithSeq, crypto.PrivKey, types.KeyID, Keeper) {
+func ctx() (types.DID, types.DIDDocumentWithSeq, crypto.PrivKey, types.VeriMethodID, Keeper) {
 	did := types.DID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
 	doc, privKey := newDIDDocumentWithSeq(did)
-	return did, doc, privKey, doc.Document.PubKeys[0].ID, newMockKeeper()
+	return did, doc, privKey, doc.Document.VeriMethods[0].ID, newMockKeeper()
 }
 
 func newDIDDocumentWithSeq(did types.DID) (types.DIDDocumentWithSeq, crypto.PrivKey) {
 	privKey := secp256k1.GenPrivKey()
-	keyID := types.NewKeyID(did, "key1")
-	pubKey := types.NewPubKey(keyID, types.ES256K, privKey.PubKey())
+	veriMethodID := types.NewVeriMethodID(did, "key1")
+	pubKey := types.NewVeriMethod(veriMethodID, types.ES256K, did, privKey.PubKey())
 	doc := types.NewDIDDocumentWithSeq(types.NewDIDDocument(did, pubKey), types.InitialSequence)
 	return doc, privKey
 }
 
-func newMsgCreateDID(t *testing.T, doc types.DIDDocument, keyID types.KeyID, privKey crypto.PrivKey) MsgCreateDID {
+func newMsgCreateDID(t *testing.T, doc types.DIDDocument, veriMethodID types.VeriMethodID, privKey crypto.PrivKey) MsgCreateDID {
 	sig, err := types.Sign(doc, types.InitialSequence, privKey)
 	require.NoError(t, err)
-	return types.NewMsgCreateDID(doc.ID, doc, keyID, sig, sdk.AccAddress{})
+	return types.NewMsgCreateDID(doc.ID, doc, veriMethodID, sig, sdk.AccAddress{})
 }
 
-func newMsgUpdateDID(t *testing.T, newDoc types.DIDDocument, keyID types.KeyID, privKey crypto.PrivKey, seq types.Sequence) MsgUpdateDID {
+func newMsgUpdateDID(t *testing.T, newDoc types.DIDDocument, veriMethodID types.VeriMethodID, privKey crypto.PrivKey, seq types.Sequence) MsgUpdateDID {
 	sig, err := types.Sign(newDoc, seq, privKey)
 	require.NoError(t, err)
-	return types.NewMsgUpdateDID(newDoc.ID, newDoc, keyID, sig, sdk.AccAddress{})
+	return types.NewMsgUpdateDID(newDoc.ID, newDoc, veriMethodID, sig, sdk.AccAddress{})
 }
 
-func newMsgDeactivateDID(t *testing.T, did types.DID, keyID types.KeyID, privKey crypto.PrivKey, seq types.Sequence) MsgDeactivateDID {
+func newMsgDeactivateDID(t *testing.T, did types.DID, veriMethodID types.VeriMethodID, privKey crypto.PrivKey, seq types.Sequence) MsgDeactivateDID {
 	sig, err := types.Sign(did, seq, privKey)
 	require.NoError(t, err)
-	return types.NewMsgDeactivateDID(did, keyID, sig, sdk.AccAddress{})
+	return types.NewMsgDeactivateDID(did, veriMethodID, sig, sdk.AccAddress{})
 }

--- a/x/did/types/errors.go
+++ b/x/did/types/errors.go
@@ -12,13 +12,14 @@ const (
 	CodeInvalidDIDDocument        sdk.CodeType = 103
 	CodeDIDNotFound               sdk.CodeType = 104
 	CodeInvalidSignature          sdk.CodeType = 105
-	CodeInvalidKeyID              sdk.CodeType = 106
-	CodeKeyIDNotFound             sdk.CodeType = 107
+	CodeInvalidVeriMethodID       sdk.CodeType = 106
+	CodeVeriMethodIDNotFound      sdk.CodeType = 107
 	CodeSigVerificationFailed     sdk.CodeType = 108
 	CodeInvalidSecp256k1PublicKey sdk.CodeType = 109
 	CodeInvalidNetworkID          sdk.CodeType = 110
 	CodeInvalidDIDDocumentWithSeq sdk.CodeType = 111
 	CodeDIDDeactivated            sdk.CodeType = 112
+	CodeInvalidKeyController      sdk.CodeType = 113
 )
 
 func ErrDIDExists(did DID) sdk.Error {
@@ -41,12 +42,12 @@ func ErrInvalidSignature(sig []byte) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidSignature, "Invalid signature %v", sig)
 }
 
-func ErrInvalidKeyID(id string) sdk.Error {
-	return sdk.NewError(DefaultCodespace, CodeInvalidKeyID, "Invalid KeyID: %s", id)
+func ErrInvalidVeriMethodID(id string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidVeriMethodID, "Invalid VeriMethodID: %s", id)
 }
 
-func ErrKeyIDNotFound(id KeyID) sdk.Error {
-	return sdk.NewError(DefaultCodespace, CodeKeyIDNotFound, "KeyID %v not found", id)
+func ErrVeriMethodIDNotFound(id VeriMethodID) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeVeriMethodIDNotFound, "VeriMethodID %v not found", id)
 }
 
 func ErrSigVerificationFailed() sdk.Error {
@@ -67,4 +68,8 @@ func ErrInvalidDIDDocumentWithSeq(doc DIDDocumentWithSeq) sdk.Error {
 
 func ErrDIDDeactivated(did DID) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeDIDDeactivated, "DID was already deactivated: %v", did)
+}
+
+func ErrInvalidKeyController(did DID) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidKeyController, "Invalid key controller: %v", did)
 }

--- a/x/did/types/msgs.go
+++ b/x/did/types/msgs.go
@@ -12,21 +12,21 @@ var (
 
 // MsgCreateDID defines a CreateDID message.
 type MsgCreateDID struct {
-	DID         DID            `json:"did"`
-	Document    DIDDocument    `json:"document"`
-	SigKeyID    KeyID          `json:"sig_key_id"`
-	Signature   []byte         `json:"signature"`
-	FromAddress sdk.AccAddress `json:"from_address"`
+	DID          DID            `json:"did"`
+	Document     DIDDocument    `json:"document"`
+	VeriMethodID VeriMethodID   `json:"verification_method_id"`
+	Signature    []byte         `json:"signature"`
+	FromAddress  sdk.AccAddress `json:"from_address"`
 }
 
 // NewMsgCreateDID is a constructor of MsgCreateDID.
-func NewMsgCreateDID(did DID, doc DIDDocument, sigKeyID KeyID, sig []byte, fromAddr sdk.AccAddress) MsgCreateDID {
+func NewMsgCreateDID(did DID, doc DIDDocument, veriMethodID VeriMethodID, sig []byte, fromAddr sdk.AccAddress) MsgCreateDID {
 	return MsgCreateDID{
-		DID:         did,
-		Document:    doc,
-		SigKeyID:    sigKeyID,
-		Signature:   sig,
-		FromAddress: fromAddr,
+		DID:          did,
+		Document:     doc,
+		VeriMethodID: veriMethodID,
+		Signature:    sig,
+		FromAddress:  fromAddr,
 	}
 }
 
@@ -65,21 +65,21 @@ func (msg MsgCreateDID) GetSigners() []sdk.AccAddress {
 
 // MsgUpdateDID defines a UpdateDID message.
 type MsgUpdateDID struct {
-	DID         DID            `json:"did"`
-	Document    DIDDocument    `json:"document"`
-	SigKeyID    KeyID          `json:"sig_key_id"`
-	Signature   []byte         `json:"signature"`
-	FromAddress sdk.AccAddress `json:"from_address"`
+	DID          DID            `json:"did"`
+	Document     DIDDocument    `json:"document"`
+	VeriMethodID VeriMethodID   `json:"verification_method_id"`
+	Signature    []byte         `json:"signature"`
+	FromAddress  sdk.AccAddress `json:"from_address"`
 }
 
 // NewMsgUpdateDID is a constructor of MsgUpdateDID.
-func NewMsgUpdateDID(did DID, doc DIDDocument, sigKeyID KeyID, sig []byte, fromAddr sdk.AccAddress) MsgUpdateDID {
+func NewMsgUpdateDID(did DID, doc DIDDocument, veriMethodID VeriMethodID, sig []byte, fromAddr sdk.AccAddress) MsgUpdateDID {
 	return MsgUpdateDID{
-		DID:         did,
-		Document:    doc,
-		SigKeyID:    sigKeyID,
-		Signature:   sig,
-		FromAddress: fromAddr,
+		DID:          did,
+		Document:     doc,
+		VeriMethodID: veriMethodID,
+		Signature:    sig,
+		FromAddress:  fromAddr,
 	}
 }
 
@@ -118,15 +118,15 @@ func (msg MsgUpdateDID) GetSigners() []sdk.AccAddress {
 
 // MsgDeactivateDID defines a UpdateDID message.
 type MsgDeactivateDID struct {
-	DID         DID            `json:"did"`
-	SigKeyID    KeyID          `json:"sig_key_id"`
-	Signature   []byte         `json:"signature"`
-	FromAddress sdk.AccAddress `json:"from_address"`
+	DID          DID            `json:"did"`
+	VeriMethodID VeriMethodID   `json:"verification_method_id"`
+	Signature    []byte         `json:"signature"`
+	FromAddress  sdk.AccAddress `json:"from_address"`
 }
 
 // NewMsgDeactivateDID is a constructor of MsgDeactivateDID.
-func NewMsgDeactivateDID(did DID, sigKeyID KeyID, sig []byte, fromAddr sdk.AccAddress) MsgDeactivateDID {
-	return MsgDeactivateDID{did, sigKeyID, sig, fromAddr}
+func NewMsgDeactivateDID(did DID, veriMethodID VeriMethodID, sig []byte, fromAddr sdk.AccAddress) MsgDeactivateDID {
+	return MsgDeactivateDID{did, veriMethodID, sig, fromAddr}
 }
 
 // Route returns the name of the module.

--- a/x/did/types/msgs_test.go
+++ b/x/did/types/msgs_test.go
@@ -21,10 +21,10 @@ func TestMsgCreateDID(t *testing.T) {
 	sig := []byte("my-sig")
 	fromAddr := getFromAddress(t)
 
-	msg := types.NewMsgCreateDID(doc.ID, doc, doc.PubKeys[0].ID, sig, fromAddr)
+	msg := types.NewMsgCreateDID(doc.ID, doc, doc.VeriMethods[0].ID, sig, fromAddr)
 	require.Equal(t, doc.ID, msg.DID)
 	require.Equal(t, doc, msg.Document)
-	require.Equal(t, doc.PubKeys[0].ID, msg.SigKeyID)
+	require.Equal(t, doc.VeriMethods[0].ID, msg.VeriMethodID)
 	require.Equal(t, sig, msg.Signature)
 	require.Equal(t, fromAddr, msg.FromAddress)
 
@@ -35,7 +35,7 @@ func TestMsgCreateDID(t *testing.T) {
 	require.Equal(t, fromAddr, msg.GetSigners()[0])
 
 	require.Equal(t,
-		`{"type":"did/MsgCreateDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","document":{"@context":"https://www.w3.org/ns/did/v1","authentication":["did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1"],"id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","publicKey":[{"id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"Secp256k1VerificationKey2018"}]},"from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","sig_key_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","signature":"bXktc2ln"}}`,
+		`{"type":"did/MsgCreateDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","document":{"@context":"https://www.w3.org/ns/did/v1","authentication":["did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1"],"id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","verificationMethod":[{"controller":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"Secp256k1VerificationKey2018"}]},"from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","signature":"bXktc2ln","verification_method_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1"}}`,
 		string(msg.GetSignBytes()),
 	)
 }
@@ -45,10 +45,10 @@ func TestMsgUpdateDID(t *testing.T) {
 	sig := []byte("my-sig")
 	fromAddr := getFromAddress(t)
 
-	msg := types.NewMsgUpdateDID(doc.ID, doc, doc.PubKeys[0].ID, sig, fromAddr)
+	msg := types.NewMsgUpdateDID(doc.ID, doc, doc.VeriMethods[0].ID, sig, fromAddr)
 	require.Equal(t, doc.ID, msg.DID)
 	require.Equal(t, doc, msg.Document)
-	require.Equal(t, doc.PubKeys[0].ID, msg.SigKeyID)
+	require.Equal(t, doc.VeriMethods[0].ID, msg.VeriMethodID)
 	require.Equal(t, sig, msg.Signature)
 	require.Equal(t, fromAddr, msg.FromAddress)
 
@@ -59,7 +59,7 @@ func TestMsgUpdateDID(t *testing.T) {
 	require.Equal(t, fromAddr, msg.GetSigners()[0])
 
 	require.Equal(t,
-		`{"type":"did/MsgUpdateDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","document":{"@context":"https://www.w3.org/ns/did/v1","authentication":["did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1"],"id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","publicKey":[{"id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"Secp256k1VerificationKey2018"}]},"from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","sig_key_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","signature":"bXktc2ln"}}`,
+		`{"type":"did/MsgUpdateDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","document":{"@context":"https://www.w3.org/ns/did/v1","authentication":["did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1"],"id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","verificationMethod":[{"controller":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"Secp256k1VerificationKey2018"}]},"from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","signature":"bXktc2ln","verification_method_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1"}}`,
 		string(msg.GetSignBytes()),
 	)
 }
@@ -69,9 +69,9 @@ func TestDeactivateDID(t *testing.T) {
 	sig := []byte("my-sig")
 	fromAddr := getFromAddress(t)
 
-	msg := types.NewMsgDeactivateDID(doc.ID, doc.PubKeys[0].ID, sig, fromAddr)
+	msg := types.NewMsgDeactivateDID(doc.ID, doc.VeriMethods[0].ID, sig, fromAddr)
 	require.Equal(t, doc.ID, msg.DID)
-	require.Equal(t, doc.PubKeys[0].ID, msg.SigKeyID)
+	require.Equal(t, doc.VeriMethods[0].ID, msg.VeriMethodID)
 	require.Equal(t, sig, msg.Signature)
 	require.Equal(t, fromAddr, msg.FromAddress)
 
@@ -82,7 +82,7 @@ func TestDeactivateDID(t *testing.T) {
 	require.Equal(t, fromAddr, msg.GetSigners()[0])
 
 	require.Equal(t,
-		`{"type":"did/MsgDeactivateDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","sig_key_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1","signature":"bXktc2ln"}}`,
+		`{"type":"did/MsgDeactivateDID","value":{"did":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP","from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","signature":"bXktc2ln","verification_method_id":"did:panacea:testnet:KS5zGZt66Me8MCctZBYrP#key1"}}`,
 		string(msg.GetSignBytes()),
 	)
 }
@@ -95,8 +95,8 @@ func getFromAddress(t *testing.T) sdk.AccAddress {
 
 func newDIDDocument() types.DIDDocument {
 	did, _ := types.ParseDID("did:panacea:testnet:KS5zGZt66Me8MCctZBYrP")
-	keyID := types.NewKeyID(did, "key1")
+	veriMethodID := types.NewVeriMethodID(did, "key1")
 	pubKeyBase58, _ := types.NewPubKeyFromBase58("qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b")
-	pubKey := types.NewPubKey(keyID, types.ES256K, pubKeyBase58)
-	return types.NewDIDDocument(did, pubKey)
+	veriMethod := types.NewVeriMethod(veriMethodID, types.ES256K, did, pubKeyBase58)
+	return types.NewDIDDocument(did, veriMethod)
 }


### PR DESCRIPTION
- On 2020-09-07, the terminology `publicKey` was changed to `verificationMethod` by W3C.
- Each `verificationMethod` must have a `controller`: [link](https://www.w3.org/TR/did-core/#verification-methods)
```
The properties MUST include the id, type, controller
```
   - Currently, I put a limitation that the `controller` must be always the same as the [DID Subject](https://www.w3.org/TR/did-core/#dfn-did-subjectshttps://www.w3.org/TR/did-core/#dfn-did-subjects), because we have never defined how to handle other DID controllers (different from the DID Subject).

TODO:
Support other DID controllers: https://www.w3.org/TR/did-core/#example-13-various-public-keys