### PR TITLE
Fix failed gentx because node is untrusted

### DIFF
--- a/init/gentx.go
+++ b/init/gentx.go
@@ -252,6 +252,7 @@ func prepareFlagsForTxCreateValidator(
 	viper.Set(client.FlagFrom, viper.GetString(client.FlagName))
 	viper.Set(cli.FlagNodeID, nodeID)
 	viper.Set(cli.FlagIP, ip)
+	viper.Set("trust-node", true)
 	viper.Set(cli.FlagPubKey, sdk.MustBech32ifyConsPub(valPubKey))
 	viper.Set(cli.FlagMoniker, config.Moniker)
 	viper.Set(cli.FlagWebsite, website)


### PR DESCRIPTION
This is a known issue fixed by https://github.com/cosmos/cosmos-sdk/pull/6021 (cosmos-sdk v0.37.11).

Because of this bug, we cannot run `panacead gentx` (https://github.com/medibloc/panacea-core/pull/54#issuecomment-696467010).

Before merging #58, let's use this temporary fix, so that `panacead gentx` can be succeeded.
If #58 is merged first, close this PR without merging.