### PR TITLE
Add a new option: halt-height

### DIFF
--- a/cmd/panacead/main.go
+++ b/cmd/panacead/main.go
@@ -75,6 +75,7 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application
 		logger, db, traceStore, true, invCheckPeriod,
 		baseapp.SetPruning(store.NewPruningOptionsFromString(viper.GetString("pruning"))),
 		baseapp.SetMinGasPrices(viper.GetString(server.FlagMinGasPrices)),
+		baseapp.SetHaltHeight(uint64(viper.GetInt(server.FlagHaltHeight))),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )
 
-replace github.com/cosmos/cosmos-sdk => github.com/medibloc/cosmos-sdk v0.35.6-internal.0.20201005064440-b291387e4dc7
+replace github.com/cosmos/cosmos-sdk => github.com/medibloc/cosmos-sdk v0.35.7-internal

--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )
 
-replace github.com/cosmos/cosmos-sdk => github.com/medibloc/cosmos-sdk v0.35.6-internal
+replace github.com/cosmos/cosmos-sdk => github.com/medibloc/cosmos-sdk v0.35.6-internal.0.20201005064440-b291387e4dc7

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/medibloc/cosmos-sdk v0.35.6-internal h1:CD4OgHu6Yq+mXror7MNZs3j2F3aAM
 github.com/medibloc/cosmos-sdk v0.35.6-internal/go.mod h1:o1VYnwY1YmUwQhLr5H7bM8o36Fnc+kwKglyrilIyzqc=
 github.com/medibloc/cosmos-sdk v0.35.6-internal.0.20201005064440-b291387e4dc7 h1:qyY4tmZ6PsaroMW8ta7UKDbHjhE9KpsCcTwVlSjFQY0=
 github.com/medibloc/cosmos-sdk v0.35.6-internal.0.20201005064440-b291387e4dc7/go.mod h1:o1VYnwY1YmUwQhLr5H7bM8o36Fnc+kwKglyrilIyzqc=
+github.com/medibloc/cosmos-sdk v0.35.7-internal h1:23RrDF9lom/keNkdxYjV5nnvtpLndpxnrhDWRCZVKAQ=
+github.com/medibloc/cosmos-sdk v0.35.7-internal/go.mod h1:o1VYnwY1YmUwQhLr5H7bM8o36Fnc+kwKglyrilIyzqc=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/medibloc/cosmos-sdk v0.35.6-internal h1:CD4OgHu6Yq+mXror7MNZs3j2F3aAMD1KAqFxdUNfgd0=
 github.com/medibloc/cosmos-sdk v0.35.6-internal/go.mod h1:o1VYnwY1YmUwQhLr5H7bM8o36Fnc+kwKglyrilIyzqc=
+github.com/medibloc/cosmos-sdk v0.35.6-internal.0.20201005064440-b291387e4dc7 h1:qyY4tmZ6PsaroMW8ta7UKDbHjhE9KpsCcTwVlSjFQY0=
+github.com/medibloc/cosmos-sdk v0.35.6-internal.0.20201005064440-b291387e4dc7/go.mod h1:o1VYnwY1YmUwQhLr5H7bM8o36Fnc+kwKglyrilIyzqc=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=


### PR DESCRIPTION
Closes #60 

This will be released as `v1.2.6-internal`.

Tests:
```
$ panacead start --halt-height 30

...
I[2020-10-13|18:00:14.889] Executed block                               module=state height=30 validTxs=0 invalidTxs=0
I[2020-10-13|18:00:14.893] halting node per configuration               module=main height=30
```