### PR TITLE
Use 'documents' as the DID genesis JSON key, instead of 'Documents'

### DIFF
--- a/x/did/types/genesis.go
+++ b/x/did/types/genesis.go
@@ -1,7 +1,7 @@
 package types
 
 type GenesisState struct {
-	Documents map[string]DIDDocumentWithSeq
+	Documents map[string]DIDDocumentWithSeq `json:"documents"`
 }
 
 func DefaultGenesisState() GenesisState {


### PR DESCRIPTION
Previously, the `genesis.json` looked like:
```json
{
  "app_state": {
    "did": {
      "Documents": {
      }
  }
}
```

Let's use `documents` instead of `Documents`.
```json
```json
{
  "app_state": {
    "did": {
      "documents": {
          "did:panacea:9iofqBjmEkL4XRiCguNxun3GVKn2Ghoqud39uS25S1aY": {
          }
      }
  }
}
```
