### PR TITLE
Fix: Make LCD use the latest height or the height specified in the URL query

### DIFF
--- a/x/aol/client/rest/query.go
+++ b/x/aol/client/rest/query.go
@@ -59,6 +59,11 @@ func listTopicHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
 		params := types.QueryListTopicParams{
 			Owner: ownerAddr,
 		}
@@ -90,6 +95,11 @@ func getTopicHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 		topicName := vars["topic"]
+
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
 
 		params := types.QueryTopicParams{
 			Owner:     ownerAddr,
@@ -123,6 +133,11 @@ func listWriterHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 		topicName := vars["topic"]
+
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
 
 		params := types.QueryListWriterParams{
 			Owner:     ownerAddr,
@@ -163,6 +178,11 @@ func getWriterHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
 		params := types.QueryWriterParams{
 			Owner:     ownerAddr,
 			TopicName: topicName,
@@ -200,6 +220,11 @@ func getRecordHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		offset, err := strconv.ParseUint(strOffset, 10, 64)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
 			return
 		}
 

--- a/x/did/client/rest/query.go
+++ b/x/did/client/rest/query.go
@@ -32,6 +32,11 @@ func getDIDHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
 		params := types.NewQueryDIDParams(id)
 		bz, err := cliCtx.Codec.MarshalJSON(params)
 		if err != nil {


### PR DESCRIPTION
Close #72 

This version was already deployed on the Testnet for Medipass (only `panaceacli`, not `panacead`).
After merging this PR, I'm gonna release v1.3.2 and deploy it.