### PR TITLE
Return 404 when DID is not found or deactivated

### DIFF
--- a/x/did/client/rest/query.go
+++ b/x/did/client/rest/query.go
@@ -51,6 +51,20 @@ func getDIDHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 		cliCtx = cliCtx.WithHeight(height)
 
+		var docWithSeq types.DIDDocumentWithSeq
+		if err := cliCtx.Codec.UnmarshalJSON(res, &docWithSeq); err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if docWithSeq.Empty() {
+			rest.WriteErrorResponse(w, http.StatusNotFound, "DID not found")
+			return
+		}
+		if docWithSeq.Deactivated() {
+			rest.WriteErrorResponse(w, http.StatusNotFound, "DID already deactivated")
+			return
+		}
+
 		rest.PostProcessResponse(w, cliCtx, res)
 	}
 }


### PR DESCRIPTION
Fix #71 

### Tests

```
(⎈ |N/A:N/A)~ ❯❯❯ curl -v localhost:1317/api/v1/did/did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    25  100    25    0     0   8333      0 --:--:-- --:--:-- --:--:--  8333
...
< HTTP/1.1 404 Not Found
...
{
  "error": "DID not found"
}

(⎈ |N/A:N/A)~ ❯❯❯ curl -v localhost:1317/api/v1/did/did:panacea:3YzwQVAXWqe6Tb7wApG98itdjjdEKKTqVdiKeHxAFD7Z | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    35  100    35    0     0  17500      0 --:--:-- --:--:-- --:--:-- 17500
...
< HTTP/1.1 404 Not Found
...
{
  "error": "DID already deactivated"
}
```

CLI has worked well. I fixed only REST.