### PR TITLE
For 1.2.7: Fix parsing keeper keys of `x/aol`

### DIFF
--- a/x/aol/keeper.go
+++ b/x/aol/keeper.go
@@ -1,8 +1,6 @@
 package aol
 
 import (
-	"bytes"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/medibloc/panacea-core/x/aol/types"
@@ -49,11 +47,11 @@ func (k Keeper) ListOwner(ctx sdk.Context) []sdk.AccAddress {
 	store := ctx.KVStore(k.storeKey)
 	addrs := make([]sdk.AccAddress, 0)
 
-	ownerKey := OwnerKey(sdk.AccAddress{})
-	iter := sdk.KVStorePrefixIterator(store, ownerKey)
+	prefix := OwnerKey(sdk.AccAddress{})
+	iter := sdk.KVStorePrefixIterator(store, prefix)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
-		addr := bytes.Split(iter.Key(), ownerKey)[1]
+		addr := getLastElement(iter.Key(), prefix)
 		addrs = append(addrs, addr)
 	}
 	return addrs
@@ -88,12 +86,12 @@ func (k Keeper) ListTopic(ctx sdk.Context, ownerAddr sdk.AccAddress) []string {
 	store := ctx.KVStore(k.storeKey)
 	topics := make([]string, 0)
 
-	topicKey := TopicKey(ownerAddr, "")
-	iter := sdk.KVStorePrefixIterator(store, topicKey)
+	prefix := TopicKey(ownerAddr, "")
+	iter := sdk.KVStorePrefixIterator(store, prefix)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
-		topic := string(bytes.Split(iter.Key(), []byte(ownerAddr))[1])
-		topics = append(topics, topic[len(KeyDelimiter):])
+		topic := getLastElement(iter.Key(), prefix)
+		topics = append(topics, string(topic))
 	}
 	return topics
 }
@@ -134,13 +132,12 @@ func (k Keeper) ListWriter(ctx sdk.Context, ownerAddr sdk.AccAddress, topic stri
 	store := ctx.KVStore(k.storeKey)
 	writers := make([]sdk.AccAddress, 0)
 
-	writerKey := ACLWriterKey(ownerAddr, topic, sdk.AccAddress{})
-	iter := sdk.KVStorePrefixIterator(store, writerKey)
+	prefix := ACLWriterKey(ownerAddr, topic, sdk.AccAddress{})
+	iter := sdk.KVStorePrefixIterator(store, prefix)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		writer := sdk.AccAddress{}
-		data := bytes.Split(iter.Key(), []byte(topic))[1]
-		data = data[len(KeyDelimiter):]
+		data := getLastElement(iter.Key(), prefix)
 		if err := writer.Unmarshal(data); err != nil {
 			return []sdk.AccAddress{}
 		}

--- a/x/aol/keeper_keys.go
+++ b/x/aol/keeper_keys.go
@@ -47,3 +47,7 @@ func RecordKey(ownerAddr sdk.AccAddress, topic string, offset uint64) []byte {
 		sdk.Uint64ToBigEndian(offset),
 	}, KeyDelimiter)
 }
+
+func getLastElement(key, prefix []byte) []byte {
+	return key[len(prefix):]
+}

--- a/x/aol/keeper_keys_test.go
+++ b/x/aol/keeper_keys_test.go
@@ -1,0 +1,26 @@
+package aol
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/medibloc/panacea-core/types/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLastElement(t *testing.T) {
+	sdk.GetConfig().SetBech32PrefixForAccount(util.Bech32PrefixAccAddr, util.Bech32PrefixAccPub)
+
+	owner, _ := sdk.AccAddressFromBech32("panacea17kmacx3czkdnhtfueqzzxk9xqzapj453f23m5a")
+	topic := string([]byte{0x88, 0x00, 0x99})
+	writer, _ := sdk.AccAddressFromBech32("panacea170vvyzwdgxrc5s5uhqhu6wdr7ppfyngfqsm6us")
+
+	ownerKey := OwnerKey(owner)
+	require.Equal(t, owner.Bytes(), getLastElement(ownerKey, OwnerKey(sdk.AccAddress{})))
+
+	topicKey := TopicKey(owner, topic)
+	require.Equal(t, []byte(topic), getLastElement(topicKey, TopicKey(owner, "")))
+
+	writerKey := ACLWriterKey(owner, topic, writer)
+	require.Equal(t, writer.Bytes(), getLastElement(writerKey, ACLWriterKey(owner, topic, sdk.AccAddress{})))
+}


### PR DESCRIPTION
Similar as the PR #82  , but based on the `v1.2.6` instead of `v1.2.6-internal`.
This fix would be released as `v1.2.7`.

