### PR TITLE
docs: Update Gitbook with the Ledger instruction

### DIFF
--- a/.gitbook/guide/installation.md
+++ b/.gitbook/guide/installation.md
@@ -4,47 +4,36 @@ This guide will explain how to install the `panacead` and `panaceacli` entrypoin
 
 ## Install Go
 
-Install `go` by following the [official docs](https://golang.org/doc/install).
+[Go 1.12+](https://golang.org/doc/install) is required.
 
-::: tip **Go 1.12+ +** is required for Panacea Core. :::
+## Install the `panacead` and `panaceacli`
 
-> _NOTE_: Before installing `panacead` and `panaceacli` binaries, let's add the golang binaries to your `PATH` variable. Open your `.bash_profile` or `.zshrc` and append `$HOME/go/bin` to your PATH variable \(i.e. `export PATH=$HOME/bin:$HOME/go/bin`\).
-
-### Install the binaries
-
-Next, let's install the latest version of Panacea Core. Here we'll use the `master` branch, which contains the latest stable release. If necessary, make sure you `git checkout` the correct released version.
+Install the latest version of Panacea Core.
 
 ```bash
 git clone https://github.com/medibloc/panacea-core
-c​d panacea-core
-git checkout master
-make
+cd panacea-core
+git checkout v1.3.3
+make install
 ```
 
-> _NOTE_: If you have issues at this step, please check that you have the latest stable version of GO installed.
-
-That will install the `panacead` and `panaceacli` binaries. Verify that everything is OK:
-
+Verify that all binaries are installed successfully.
 ```bash
 $ panacead version --long
+name: panacea-core
+server_name: panacead
+client_name: panaceacli
+version: 1.3.3
+commit: 2dfceffc647db15499c715e8833c5e379c04e028
+build_tags: ' ledger'
+go: go version go1.15.5 darwin/amd64
+
 $ panaceacli version --long
+name: panacea-core
+server_name: panacead
+client_name: panaceacli
+version: 1.3.3
+commit: 2dfceffc647db15499c715e8833c5e379c04e028
+build_tags: ' ledger'
+go: go version go1.15.5 darwin/amd64
 ```
-
-`panaceacli` for instance should output something similar to:
-
-```text
-panacea_core: 0.0.2-25-ga25419b
-commit: a25419bd3ffa07dde59f352dd015d2dd859227ef
-go_sum_hash: ff10edafbe07b3e3aa879b1204cab0528ab002b0c4b37fa9dbf97e5117339e24
-build tags: ledger
-go version go1.12.4 darwin/amd64
-```
-
-### Build Tags
-
-Build tags indicate special features that have been enabled in the binary.
-
-| Build Tag | Description |
-| :--- | :--- |
-| ledger | Ledger devices are supported \(hardware wallets\) |
-

--- a/.gitbook/guide/use-the-ledger-nano.md
+++ b/.gitbook/guide/use-the-ledger-nano.md
@@ -1,4 +1,87 @@
-# ​Use the Ledger Nano‌
+# Ledger Nano Support
 
-To Be Updated
+Using a hardware wallet to store your keys improves the security of your assets. 
+The [Ledger](https://www.ledger.com/) device acts as an enclave of the seed and private keys,
+and the process of signing transaction takes place within it.
+The following is a short tutorial on using the Panacea Ledger app with the Panacea CLI.
 
+
+## Install the Panacea Ledger app
+
+Installing the `Panacea` app on your Ledger device is required before using the Panacea CLI.
+
+1. Install [Ledger Live](https://www.ledger.com/ledger-live/) on your machine.
+2. Using Ledger Live, update your Ledger Nano device with the latest firmware.
+3. Navigate to the `Manager` menu on the Ledger Live.
+4. Connect you Ledger Nano device and allow Ledger Manager from it.
+5. On the Ledger Live, search for `Panacea` and install it.
+
+
+## Panacea CLI + Ledger Nano
+
+Note: You need to [install the `Panacea` app](#install-the-panacea-ledger-app) on your Ledger Nano device before using following this section.
+
+### Before you begin
+
+Install `panaceacli` by following the [guide](installation.md).
+
+### Add your Ledger key
+
+- Connect and unlock your Ledger Nano device.
+- Open the `Panacea` app on your Ledger Nano device.
+- Create an account in `panaceacli` from your Ledger key.
+
+```bash
+panaceacli keys add <keyName> --ledger
+```
+Note: Be sure to change the `<keyName>` parameter to be a meaningful name. The `--ledger` flag tells `panaceacli` to use your Ledger to seed the account.
+
+Panacea uses HD wallets. This means you can setup many accounts using the same Ledger seed.
+To create another account from your Ledger device, run the following command by changing the integer `<i>`
+to some value >= 0 to choose the account for HD derivation.
+```bash
+panaceacli keys add <keyName> --ledger --account <i>
+```
+
+### Confirm your address
+
+Run the following command to display your address on the Ledger Nano device. Use the `<keyName>` you gave your Ledger key.
+```bash
+panaceacli keys show <keyName> -d
+```
+
+Confirm that the address displayed on the Ledger Nano device matches that displayed when you added the key.
+
+### Sign a transaction (Send funds)
+
+You are now ready to start signing and sending transactions.
+```bash
+panaceacli tx send <fromAddress> <toAddress> <amount>umed \
+  --node http://54.180.169.37:26657 \
+  --chain-id panacea-2 \
+  --fees 1000000umed
+```
+Be sure to set a proper full node address to the `--node` parameter. In the above example, one of the [Panacea Mainnet full nodes](https://github.com/medibloc/panacea-launch) was used.
+Also, the `--chain-id` must be set as `panacea-2` which is the current chain ID of the Panacea Mainnet.
+
+For `--fees`, please set `1000000umed` which is the approximate minimum in the current Mainnet network.
+
+You will be prompted to review and approve the transaction on your Ledger Nano device.
+Be sure to inspect the transaction displayed on the screen.
+
+### Receive funds
+
+To receive funds to the Panacea account on your Ledger Nano device,
+retrieve the address for your Ledger Nano device (the ones with `type: ledger`) with this command:
+```bash
+panaceacli keys list
+
+- name: <keyName>
+  type: ledger
+  address: panacea1...
+```
+
+### Support
+
+For further support,
+- support@gopanacea.org


### PR DESCRIPTION
In order to publish the `Panacea` app to [Ledger Live](https://www.ledger.com/ledger-live), we have to provide them a proper manual how to install/run Panacea Ledger app with proper Panacea tools (such as `panaceacli`).

The guildeline is https://docs.google.com/document/d/1QI7DHd3HIyhKWydlmjBbB-dlUXquqAd-4f4ED_-wgAU/edit