### PR TITLE
x/token: Fix to update the total supply of all coins when issuing new tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-TBD
+### Bug fixes
+
+- [\#95](https://github.com/medibloc/panacea-core/pull/95) x/token: Fix to update the total supply of all coins when issuing new tokens
+
 
 ## [v1.3.3](https://github.com/medibloc/panacea-core/releases/tag/v1.3.3) - 2020-12-03
 

--- a/app/app.go
+++ b/app/app.go
@@ -222,6 +222,7 @@ func NewPanaceaApp(
 		keys[token.StoreKey],
 		app.cdc,
 		app.bankKeeper,
+		app.supplyKeeper,
 	)
 
 	// register the staking hooks

--- a/x/token/keeper/keeper.go
+++ b/x/token/keeper/keeper.go
@@ -55,7 +55,7 @@ func (k tokenKeeper) SetToken(ctx sdk.Context, symbol types.Symbol, token types.
 	newTotal := supply.GetTotal().Add(newCoins)
 	k.supplyKeeper.SetSupply(ctx, supply.SetTotal(newTotal))
 
-	// Deposit the total supply to the owner account
+	// Deposit the total supply of the new coin to the owner account
 	if _, err := k.bankKeeper.AddCoins(ctx, token.OwnerAddress, newCoins); err != nil {
 		panic(err)
 	}

--- a/x/token/keeper/keeper.go
+++ b/x/token/keeper/keeper.go
@@ -24,15 +24,17 @@ type tokenKeeper struct {
 	cdc *codec.Codec
 
 	// External keepers
-	bankKeeper types.BankKeeper
+	bankKeeper   types.BankKeeper
+	supplyKeeper types.SupplyKeeper
 }
 
 // NewKeeper creates a new instance of the token Keeper
-func NewKeeper(storeKey sdk.StoreKey, cdc *codec.Codec, bankKeeper types.BankKeeper) Keeper {
+func NewKeeper(storeKey sdk.StoreKey, cdc *codec.Codec, bankKeeper types.BankKeeper, supplyKeeper types.SupplyKeeper) Keeper {
 	return tokenKeeper{
-		storeKey:   storeKey,
-		cdc:        cdc,
-		bankKeeper: bankKeeper,
+		storeKey:     storeKey,
+		cdc:          cdc,
+		bankKeeper:   bankKeeper,
+		supplyKeeper: supplyKeeper,
 	}
 }
 
@@ -46,8 +48,15 @@ func (k tokenKeeper) SetToken(ctx sdk.Context, symbol types.Symbol, token types.
 	bz := k.cdc.MustMarshalBinaryLengthPrefixed(token)
 	store.Set(key, bz)
 
+	newCoins := sdk.NewCoins(token.TotalSupply)
+
+	// Update the total supply of all coins
+	supply := k.supplyKeeper.GetSupply(ctx)
+	newTotal := supply.GetTotal().Add(newCoins)
+	k.supplyKeeper.SetSupply(ctx, supply.SetTotal(newTotal))
+
 	// Deposit the total supply to the owner account
-	if _, err := k.bankKeeper.AddCoins(ctx, token.OwnerAddress, sdk.NewCoins(token.TotalSupply)); err != nil {
+	if _, err := k.bankKeeper.AddCoins(ctx, token.OwnerAddress, newCoins); err != nil {
 		panic(err)
 	}
 }

--- a/x/token/types/expected_keepers.go
+++ b/x/token/types/expected_keepers.go
@@ -1,8 +1,17 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/supply/exported"
+)
 
 // BankKeeper defines the expected bank Keeper
 type BankKeeper interface {
 	AddCoins(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coins) (sdk.Coins, sdk.Error)
+}
+
+// SupplyKeeper defines the expected bank Keeper
+type SupplyKeeper interface {
+	GetSupply(ctx sdk.Context) (supply exported.SupplyI)
+	SetSupply(ctx sdk.Context, supply exported.SupplyI)
 }


### PR DESCRIPTION
Fixes #93 

No unit test yet. Unit tests will be added soon by following the Cosmos-SDK's way (probably in the newer Cosmos version).

A manual test was done:
```bash
panacead export --for-zero-height --height=10
```
```json
    "supply": {
      "supply": [
        {
          "amount": "1000000000",
          "denom": "ulov221"
        },
        {
          "amount": "100000001584400",
          "denom": "umed"
        }
      ]
    },
    "token": {
      "tokens": {
        "LOV-221": {
          "mintable": false,
          "name": "love",
          "owner_address": "panacea1xs5e3p3jxfxr3n9xluagkgnxxk9vpcm0dcrew2",
          "symbol": "LOV-221",
          "total_supply": {
            "amount": "1000000000",
            "denom": "ulov221"
          }
        }
      }
    }
```
