### PR TITLE
x/did: Support service / controller / various verificationRelationship in DID Document

### DIFF
--- a/x/did/client/cli/tx_test.go
+++ b/x/did/client/cli/tx_test.go
@@ -38,9 +38,9 @@ func TestNewMsgCreateDID(t *testing.T) {
 	msg, err := newMsgCreateDID(getCliContext(t), privKey)
 	require.NoError(t, err)
 
-	// check if veriMethod is correct
-	veriMethod, _ := msg.Document.VeriMethodByID(msg.VeriMethodID)
-	pubKey, _ := secp256k1util.PubKeyFromBase58(veriMethod.PubKeyBase58)
+	// check if verificationMethod is correct
+	verificationMethod, _ := msg.Document.VerificationMethodByID(msg.VerificationMethodID)
+	pubKey, _ := secp256k1util.PubKeyFromBase58(verificationMethod.PubKeyBase58)
 	require.Equal(t, privKey.PubKey(), pubKey)
 
 	// check if the signature can be verifiable with the initial sequence
@@ -107,14 +107,14 @@ func TestReadBIP39ParamsFrom_InvalidMnemonic(t *testing.T) {
 
 // Check if the private key is stored and loaded correctly by the password specified.
 func TestSaveAndGetPrivKeyFromKeyStore(t *testing.T) {
-	veriMethodID := types.VeriMethodID("key1")
+	verificationMethodID := types.VerificationMethodID("key1")
 	privKey, _ := crypto.GenSecp256k1PrivKey("", "")
 
 	reader := bufio.NewReader(strings.NewReader("mypassword1\nmypassword1\n"))
-	require.NoError(t, savePrivKeyToKeyStore(veriMethodID, privKey, reader))
+	require.NoError(t, savePrivKeyToKeyStore(verificationMethodID, privKey, reader))
 
 	reader = bufio.NewReader(strings.NewReader("mypassword1\n"))
-	privKeyLoaded, err := getPrivKeyFromKeyStore(veriMethodID, reader)
+	privKeyLoaded, err := getPrivKeyFromKeyStore(verificationMethodID, reader)
 	require.NoError(t, err)
 	require.Equal(t, privKey, privKeyLoaded)
 }

--- a/x/did/handler.go
+++ b/x/did/handler.go
@@ -39,7 +39,7 @@ func handleMsgCreateDID(ctx sdk.Context, keeper keeper.Keeper, msg MsgCreateDID)
 
 	seq := types.InitialSequence
 
-	_, err := verifyDIDOwnership(msg.Document, seq, msg.Document, msg.VeriMethodID, msg.Signature)
+	_, err := verifyDIDOwnership(msg.Document, seq, msg.Document, msg.VerificationMethodID, msg.Signature)
 	if err != nil {
 		return err.Result()
 	}
@@ -58,7 +58,7 @@ func handleMsgUpdateDID(ctx sdk.Context, keeper keeper.Keeper, msg MsgUpdateDID)
 		return types.ErrDIDDeactivated(msg.DID).Result()
 	}
 
-	newSeq, err := verifyDIDOwnership(msg.Document, docWithSeq.Seq, docWithSeq.Document, msg.VeriMethodID, msg.Signature)
+	newSeq, err := verifyDIDOwnership(msg.Document, docWithSeq.Seq, docWithSeq.Document, msg.VerificationMethodID, msg.Signature)
 	if err != nil {
 		return err.Result()
 	}
@@ -77,7 +77,7 @@ func handleMsgDeactivateDID(ctx sdk.Context, keeper keeper.Keeper, msg MsgDeacti
 		return types.ErrDIDDeactivated(msg.DID).Result()
 	}
 
-	newSeq, err := verifyDIDOwnership(msg.DID, docWithSeq.Seq, docWithSeq.Document, msg.VeriMethodID, msg.Signature)
+	newSeq, err := verifyDIDOwnership(msg.DID, docWithSeq.Seq, docWithSeq.Document, msg.VerificationMethodID, msg.Signature)
 	if err != nil {
 		return err.Result()
 	}
@@ -90,19 +90,19 @@ func handleMsgDeactivateDID(ctx sdk.Context, keeper keeper.Keeper, msg MsgDeacti
 // verifyDIDOwnership verifies the DID ownership from a sig which is covers a DID Document + a sequence number.
 // A public key is taken from one of verificationMethods in the DID Document.
 // If the verification is successful, it returns a new sequence. If not, it returns an error.
-func verifyDIDOwnership(data types.Signable, seq types.Sequence, doc types.DIDDocument, veriMethodID types.VeriMethodID, sig []byte) (types.Sequence, sdk.Error) {
-	veriMethod, ok := doc.VeriMethodByID(veriMethodID)
+func verifyDIDOwnership(data types.Signable, seq types.Sequence, doc types.DIDDocument, verificationMethodID types.VerificationMethodID, sig []byte) (types.Sequence, sdk.Error) {
+	verificationMethod, ok := doc.VerificationMethodByID(verificationMethodID)
 	if !ok {
-		return 0, types.ErrVeriMethodIDNotFound(veriMethodID)
+		return 0, types.ErrVerificationMethodIDNotFound(verificationMethodID)
 	}
 
 	// TODO: Currently, only ES256K1 is supported to verify DID ownership.
 	//       It makes sense for now, since a DID is derived from a Secp256k1 public key.
-	//       But, need to support other key types (according to veriMethod.Type).
-	if veriMethod.Type != types.ES256K_2019 && veriMethod.Type != types.ES256K_2018 {
-		return 0, types.ErrVeriMethodKeyTypeNotImplemented(veriMethod.Type)
+	//       But, need to support other key types (according to verificationMethod.Type).
+	if verificationMethod.Type != types.ES256K_2019 && verificationMethod.Type != types.ES256K_2018 {
+		return 0, types.ErrVerificationMethodKeyTypeNotImplemented(verificationMethod.Type)
 	}
-	pubKeySecp256k1, err := secp256k1util.PubKeyFromBase58(veriMethod.PubKeyBase58)
+	pubKeySecp256k1, err := secp256k1util.PubKeyFromBase58(verificationMethod.PubKeyBase58)
 	if err != nil {
 		return 0, types.ErrInvalidSecp256k1PublicKey(err)
 	}

--- a/x/did/keeper/genesis_test.go
+++ b/x/did/keeper/genesis_test.go
@@ -83,13 +83,16 @@ func (k mockKeeper) ListDIDs(ctx sdk.Context) []types.DID {
 func newDIDDocumentWithSeq(did types.DID) (types.DIDDocumentWithSeq, crypto.PrivKey) {
 	privKey := secp256k1.GenPrivKey()
 	pubKey := secp256k1util.PubKeyBytes(secp256k1util.DerivePubKey(privKey))
-	veriMethodID := types.NewVeriMethodID(did, "key1")
-	veriMethods := []types.VeriMethod{
-		types.NewVeriMethod(veriMethodID, types.ES256K_2019, did, pubKey),
+	verificationMethodID := types.NewVerificationMethodID(did, "key1")
+	verificationMethods := []types.VerificationMethod{
+		types.NewVerificationMethod(verificationMethodID, types.ES256K_2019, did, pubKey),
 	}
-	authentications := []types.Authentication{
-		types.NewAuthentication(veriMethods[0].ID),
+	authentications := []types.VerificationRelationship{
+		types.NewVerificationRelationship(verificationMethods[0].ID),
 	}
-	doc := types.NewDIDDocumentWithSeq(types.NewDIDDocument(did, veriMethods, authentications), types.InitialSequence)
+	doc := types.NewDIDDocumentWithSeq(
+		types.NewDIDDocument(did, types.WithVerificationMethods(verificationMethods), types.WithAuthentications(authentications)),
+		types.InitialSequence,
+	)
 	return doc, privKey
 }

--- a/x/did/types/did_test.go
+++ b/x/did/types/did_test.go
@@ -49,15 +49,22 @@ func TestDID_GetSignBytes(t *testing.T) {
 func TestNewDIDDocument(t *testing.T) {
 	did := DID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
 	pubKey := secp256k1util.PubKeyBytes(secp256k1util.DerivePubKey(secp256k1.GenPrivKey()))
-	veriMethodID := NewVeriMethodID(did, "key1")
-	veriMethods := []VeriMethod{NewVeriMethod(veriMethodID, ES256K_2019, did, pubKey)}
-	authentications := []Authentication{NewAuthentication(veriMethods[0].ID)}
+	verificationMethodID := NewVerificationMethodID(did, "key1")
+	verificationMethods := []VerificationMethod{NewVerificationMethod(verificationMethodID, ES256K_2019, did, pubKey)}
+	authentications := []VerificationRelationship{NewVerificationRelationship(verificationMethods[0].ID)}
+	services := []Service{NewService("service1", "LinkedDomains", "https://service.org")}
 
-	doc := NewDIDDocument(did, veriMethods, authentications)
+	doc := NewDIDDocument(did, WithVerificationMethods(verificationMethods), WithAuthentications(authentications), WithServices(services))
 	require.True(t, doc.Valid())
 	require.Equal(t, did, doc.ID)
-	require.EqualValues(t, veriMethods, doc.VeriMethods)
+	require.Empty(t, doc.Controller)
+	require.EqualValues(t, verificationMethods, doc.VerificationMethods)
 	require.EqualValues(t, authentications, doc.Authentications)
+	require.Empty(t, doc.AssertionMethods)
+	require.Empty(t, doc.KeyAgreements)
+	require.Empty(t, doc.CapabilityInvocations)
+	require.Empty(t, doc.CapabilityDelegations)
+	require.EqualValues(t, services, doc.Services)
 }
 
 func TestDIDDocument_Empty(t *testing.T) {
@@ -65,23 +72,44 @@ func TestDIDDocument_Empty(t *testing.T) {
 	require.True(t, DIDDocument{}.Empty())
 }
 
-func TestDIDDocument_VeriMethodByID(t *testing.T) {
+func TestDIDDocument_Invalid(t *testing.T) {
+	did := DID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
+	invalidVerificationRelationships := []VerificationRelationship{
+		NewVerificationRelationship(NewVerificationMethodID("invalid did", "key1")),
+	}
+	invalidServices := []Service{
+		NewService("", "", ""),
+	}
+
+	require.False(t, NewDIDDocument("invalid did").Valid())
+	require.False(t, NewDIDDocument(did, WithController("invalid did")).Valid())
+	require.False(t, NewDIDDocument(did, WithAuthentications(invalidVerificationRelationships)).Valid())
+	require.False(t, NewDIDDocument(did, WithAssertionMethods(invalidVerificationRelationships)).Valid())
+	require.False(t, NewDIDDocument(did, WithKeyAgreements(invalidVerificationRelationships)).Valid())
+	require.False(t, NewDIDDocument(did, WithCapabilityInvocations(invalidVerificationRelationships)).Valid())
+	require.False(t, NewDIDDocument(did, WithCapabilityDelegations(invalidVerificationRelationships)).Valid())
+	require.False(t, NewDIDDocument(did, WithCapabilityDelegations(invalidVerificationRelationships)).Valid())
+	require.False(t, NewDIDDocument(did, WithCapabilityDelegations(invalidVerificationRelationships)).Valid())
+	require.False(t, NewDIDDocument(did, WithServices(invalidServices)).Valid())
+}
+
+func TestDIDDocument_VerificationMethodByID(t *testing.T) {
 	did := DID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
 	pubKey := secp256k1util.PubKeyBytes(secp256k1util.DerivePubKey(secp256k1.GenPrivKey()))
-	veriMethodID := NewVeriMethodID(did, "key1")
-	veriMethods := []VeriMethod{NewVeriMethod(veriMethodID, ES256K_2019, did, pubKey)}
-	authentications := []Authentication{NewAuthentication(veriMethods[0].ID)}
-	doc := NewDIDDocument(did, veriMethods, authentications)
+	verificationMethodID := NewVerificationMethodID(did, "key1")
+	verificationMethods := []VerificationMethod{NewVerificationMethod(verificationMethodID, ES256K_2019, did, pubKey)}
+	authentications := []VerificationRelationship{NewVerificationRelationship(verificationMethods[0].ID)}
+	doc := NewDIDDocument(did, WithVerificationMethods(verificationMethods), WithAuthentications(authentications))
 
-	found, ok := doc.VeriMethodByID(veriMethodID)
+	found, ok := doc.VerificationMethodByID(verificationMethodID)
 	require.True(t, ok)
-	require.Equal(t, veriMethods[0], found)
+	require.Equal(t, verificationMethods[0], found)
 
-	_, ok = doc.VeriMethodByID(NewVeriMethodID(did, "key2"))
+	_, ok = doc.VerificationMethodByID(NewVerificationMethodID(did, "key2"))
 	require.False(t, ok)
 
-	doc.Authentications = []Authentication{} // clear authentications
-	_, ok = doc.VeriMethodByID(veriMethodID)
+	doc.Authentications = []VerificationRelationship{} // clear authentications
+	_, ok = doc.VerificationMethodByID(verificationMethodID)
 	require.False(t, ok)
 }
 
@@ -118,41 +146,41 @@ func TestContexts_UnmarshalJSON(t *testing.T) {
 	require.Equal(t, Contexts{ContextDIDV1}, ctxs)
 }
 
-func TestNewVeriMethodID(t *testing.T) {
+func TestNewVerificationMethodID(t *testing.T) {
 	did := DID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
 	expectedID := fmt.Sprintf("%s#key1", did)
-	id := NewVeriMethodID(did, "key1")
+	id := NewVerificationMethodID(did, "key1")
 	require.True(t, id.Valid(did))
 	require.EqualValues(t, expectedID, id)
 
-	id, err := ParseVeriMethodID(expectedID, did)
+	id, err := ParseVerificationMethodID(expectedID, did)
 	require.NoError(t, err)
 	require.EqualValues(t, expectedID, id)
 }
 
-func TestVeriMethodID_Valid(t *testing.T) {
+func TestVerificationMethodID_Valid(t *testing.T) {
 	// normal
-	require.True(t, VeriMethodID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
+	require.True(t, VerificationMethodID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
 
 	// if suffix has whitespaces
-	require.False(t, VeriMethodID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm# key1").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
-	require.False(t, VeriMethodID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1 ").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
+	require.False(t, VerificationMethodID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm# key1").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
+	require.False(t, VerificationMethodID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1 ").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
 
 	// if suffix is empty
-	require.False(t, VeriMethodID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
-	require.False(t, VeriMethodID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
+	require.False(t, VerificationMethodID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
+	require.False(t, VerificationMethodID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
 
 	// if prefix (DID) is invalid
-	require.False(t, VeriMethodID("invalid#key1").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
-	require.False(t, VeriMethodID("did:panacea:87nZqL3ny7aR7C7Prd74ry1Uctg46JamVbJgk8azVgUm#key1").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
+	require.False(t, VerificationMethodID("invalid#key1").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
+	require.False(t, VerificationMethodID("did:panacea:87nZqL3ny7aR7C7Prd74ry1Uctg46JamVbJgk8azVgUm#key1").Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
 
 	// if suffix is too long
 	var builder strings.Builder
 	builder.WriteString("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#")
-	for i := 0; i < maxVeriMethodIDLen+1; i++ {
+	for i := 0; i < maxVerificationMethodIDLen+1; i++ {
 		builder.WriteByte('k')
 	}
-	require.False(t, VeriMethodID(builder.String()).Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
+	require.False(t, VerificationMethodID(builder.String()).Valid("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm"))
 }
 
 func TestKeyType_Valid(t *testing.T) {
@@ -161,68 +189,75 @@ func TestKeyType_Valid(t *testing.T) {
 	require.False(t, KeyType("").Valid())
 }
 
-func TestNewVeriMethod(t *testing.T) {
+func TestNewVerificationMethod(t *testing.T) {
 	did := DID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
 	pubKey := secp256k1util.PubKeyBytes(secp256k1util.DerivePubKey(secp256k1.GenPrivKey()))
-	pub := NewVeriMethod(NewVeriMethodID(did, "key1"), ES256K_2019, did, pubKey)
+	pub := NewVerificationMethod(NewVerificationMethodID(did, "key1"), ES256K_2019, did, pubKey)
 	require.True(t, pub.Valid(did))
 
 	require.Equal(t, pubKey[:], base58.Decode(pub.PubKeyBase58))
 }
 
-func TestAuthentication_Valid(t *testing.T) {
+func TestVerificationRelationship_Valid(t *testing.T) {
 	did := DID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
 	pubKey := secp256k1util.PubKeyBytes(secp256k1util.DerivePubKey(secp256k1.GenPrivKey()))
-	veriMethodID := NewVeriMethodID(did, "key1")
-	veriMethod := NewVeriMethod(veriMethodID, ES256K_2019, did, pubKey)
+	verificationMethodID := NewVerificationMethodID(did, "key1")
+	verificationMethod := NewVerificationMethod(verificationMethodID, ES256K_2019, did, pubKey)
 
-	auth := Authentication{VeriMethodID: veriMethodID, DedicatedMethod: nil}
+	auth := VerificationRelationship{VerificationMethodID: verificationMethodID, DedicatedVerificationMethod: nil}
 	require.True(t, auth.Valid(did))
-	auth = Authentication{VeriMethodID: veriMethodID, DedicatedMethod: &veriMethod}
+	auth = VerificationRelationship{VerificationMethodID: verificationMethodID, DedicatedVerificationMethod: &verificationMethod}
 	require.True(t, auth.Valid(did))
 
-	auth = Authentication{VeriMethodID: "invalid", DedicatedMethod: nil}
+	auth = VerificationRelationship{VerificationMethodID: "invalid", DedicatedVerificationMethod: nil}
 	require.False(t, auth.Valid(did))
-	auth = Authentication{VeriMethodID: veriMethodID, DedicatedMethod: &VeriMethod{ID: "invalid"}}
+	auth = VerificationRelationship{VerificationMethodID: verificationMethodID, DedicatedVerificationMethod: &VerificationMethod{ID: "invalid"}}
 	require.False(t, auth.Valid(did))
-	auth = Authentication{VeriMethodID: NewVeriMethodID(did, "key2"), DedicatedMethod: &veriMethod}
+	auth = VerificationRelationship{VerificationMethodID: NewVerificationMethodID(did, "key2"), DedicatedVerificationMethod: &verificationMethod}
 	require.False(t, auth.Valid(did))
 }
 
-func TestAuthentication_MarshalJSON(t *testing.T) {
+func TestVerificationRelationship_MarshalJSON(t *testing.T) {
 	did := DID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
 	pubKey := secp256k1util.PubKeyBytes(secp256k1util.DerivePubKey(secp256k1.GenPrivKey()))
-	veriMethodID := NewVeriMethodID(did, "key1")
-	veriMethod := NewVeriMethod(veriMethodID, ES256K_2019, did, pubKey)
+	verificationMethodID := NewVerificationMethodID(did, "key1")
+	verificationMethod := NewVerificationMethod(verificationMethodID, ES256K_2019, did, pubKey)
 
-	auth := NewAuthentication(veriMethodID)
+	auth := NewVerificationRelationship(verificationMethodID)
 	bz, err := auth.MarshalJSON()
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf(`"%v"`, veriMethodID), string(bz))
+	require.Equal(t, fmt.Sprintf(`"%v"`, verificationMethodID), string(bz))
 
-	auth = NewAuthenticationDedicated(veriMethod)
+	auth = NewVerificationRelationshipDedicated(verificationMethod)
 	bz, err = auth.MarshalJSON()
 	require.NoError(t, err)
-	regex := fmt.Sprintf(`{"id":"%v","type":"%v","controller":"%v","publicKeyBase58":"%v"}`, veriMethodID, ES256K_2019, did, veriMethod.PubKeyBase58)
+	regex := fmt.Sprintf(`{"id":"%v","type":"%v","controller":"%v","publicKeyBase58":"%v"}`, verificationMethodID, ES256K_2019, did, verificationMethod.PubKeyBase58)
 	require.Regexp(t, regex, string(bz))
 }
 
-func TestAuthentication_UnmarshalJSON(t *testing.T) {
+func TestVerificationRelationship_UnmarshalJSON(t *testing.T) {
 	did := DID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
 	pubKey := secp256k1util.PubKeyBytes(secp256k1util.DerivePubKey(secp256k1.GenPrivKey()))
-	veriMethodID := NewVeriMethodID(did, "key1")
-	veriMethod := NewVeriMethod(veriMethodID, ES256K_2019, did, pubKey)
+	verificationMethodID := NewVerificationMethodID(did, "key1")
+	verificationMethod := NewVerificationMethod(verificationMethodID, ES256K_2019, did, pubKey)
 
-	var auth Authentication
-	bz := []byte(fmt.Sprintf(`"%v"`, veriMethodID))
+	var auth VerificationRelationship
+	bz := []byte(fmt.Sprintf(`"%v"`, verificationMethodID))
 	require.NoError(t, auth.UnmarshalJSON(bz))
-	require.Equal(t, NewAuthentication(veriMethodID), auth)
+	require.Equal(t, NewVerificationRelationship(verificationMethodID), auth)
 	require.True(t, auth.Valid(did))
 
-	bz = []byte(fmt.Sprintf(`{"id":"%v","type":"%v","controller":"%v","publicKeyBase58":"%v"}`, veriMethodID, ES256K_2019, did, veriMethod.PubKeyBase58))
+	bz = []byte(fmt.Sprintf(`{"id":"%v","type":"%v","controller":"%v","publicKeyBase58":"%v"}`, verificationMethodID, ES256K_2019, did, verificationMethod.PubKeyBase58))
 	require.NoError(t, auth.UnmarshalJSON(bz))
-	require.Equal(t, NewAuthenticationDedicated(veriMethod), auth)
+	require.Equal(t, NewVerificationRelationshipDedicated(verificationMethod), auth)
 	require.True(t, auth.Valid(did))
+}
+
+func TestService_Valid(t *testing.T) {
+	require.True(t, NewService("service1", "LinkedDomains", "https://domain.com").Valid())
+	require.False(t, NewService("", "LinkedDomains", "https://domain.com").Valid())
+	require.False(t, NewService("service1", "", "https://domain.com").Valid())
+	require.False(t, NewService("service1", "LinkedDomains", "").Valid())
 }
 
 func TestDIDDocumentWithSeq_Empty(t *testing.T) {
@@ -249,8 +284,8 @@ func TestDIDDocumentWithSeq_Deactivate(t *testing.T) {
 func getValidDIDDocument() DIDDocument {
 	did := DID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
 	pubKey := secp256k1util.PubKeyBytes(secp256k1util.DerivePubKey(secp256k1.GenPrivKey()))
-	veriMethodID := NewVeriMethodID(did, "key1")
-	veriMethods := []VeriMethod{NewVeriMethod(veriMethodID, ES256K_2019, did, pubKey)}
-	authentications := []Authentication{NewAuthentication(veriMethods[0].ID)}
-	return NewDIDDocument(did, veriMethods, authentications)
+	verificationMethodID := NewVerificationMethodID(did, "key1")
+	verificationMethods := []VerificationMethod{NewVerificationMethod(verificationMethodID, ES256K_2019, did, pubKey)}
+	authentications := []VerificationRelationship{NewVerificationRelationship(verificationMethods[0].ID)}
+	return NewDIDDocument(did, WithVerificationMethods(verificationMethods), WithAuthentications(authentications))
 }

--- a/x/did/types/errors.go
+++ b/x/did/types/errors.go
@@ -7,20 +7,20 @@ import (
 const DefaultCodespace sdk.CodespaceType = ModuleName
 
 const (
-	CodeDIDExists                       sdk.CodeType = 101
-	CodeInvalidDID                      sdk.CodeType = 102
-	CodeInvalidDIDDocument              sdk.CodeType = 103
-	CodeDIDNotFound                     sdk.CodeType = 104
-	CodeInvalidSignature                sdk.CodeType = 105
-	CodeInvalidVeriMethodID             sdk.CodeType = 106
-	CodeVeriMethodIDNotFound            sdk.CodeType = 107
-	CodeSigVerificationFailed           sdk.CodeType = 108
-	CodeInvalidSecp256k1PublicKey       sdk.CodeType = 109
-	CodeInvalidNetworkID                sdk.CodeType = 110
-	CodeInvalidDIDDocumentWithSeq       sdk.CodeType = 111
-	CodeDIDDeactivated                  sdk.CodeType = 112
-	CodeInvalidKeyController            sdk.CodeType = 113
-	CodeVeriMethodKeyTypeNotImplemented sdk.CodeType = 114
+	CodeDIDExists                               sdk.CodeType = 101
+	CodeInvalidDID                              sdk.CodeType = 102
+	CodeInvalidDIDDocument                      sdk.CodeType = 103
+	CodeDIDNotFound                             sdk.CodeType = 104
+	CodeInvalidSignature                        sdk.CodeType = 105
+	CodeInvalidVerificationMethodID             sdk.CodeType = 106
+	CodeVerificationMethodIDNotFound            sdk.CodeType = 107
+	CodeSigVerificationFailed                   sdk.CodeType = 108
+	CodeInvalidSecp256k1PublicKey               sdk.CodeType = 109
+	CodeInvalidNetworkID                        sdk.CodeType = 110
+	CodeInvalidDIDDocumentWithSeq               sdk.CodeType = 111
+	CodeDIDDeactivated                          sdk.CodeType = 112
+	CodeInvalidKeyController                    sdk.CodeType = 113
+	CodeVerificationMethodKeyTypeNotImplemented sdk.CodeType = 114
 )
 
 func ErrDIDExists(did DID) sdk.Error {
@@ -43,12 +43,12 @@ func ErrInvalidSignature(sig []byte) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidSignature, "Invalid signature %v", sig)
 }
 
-func ErrInvalidVeriMethodID(id string) sdk.Error {
-	return sdk.NewError(DefaultCodespace, CodeInvalidVeriMethodID, "Invalid VeriMethodID: %s", id)
+func ErrInvalidVerificationMethodID(id string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidVerificationMethodID, "Invalid VerificationMethodID: %s", id)
 }
 
-func ErrVeriMethodIDNotFound(id VeriMethodID) sdk.Error {
-	return sdk.NewError(DefaultCodespace, CodeVeriMethodIDNotFound, "VeriMethodID %v not found", id)
+func ErrVerificationMethodIDNotFound(id VerificationMethodID) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeVerificationMethodIDNotFound, "VerificationMethodID %v not found", id)
 }
 
 func ErrSigVerificationFailed() sdk.Error {
@@ -75,6 +75,6 @@ func ErrInvalidKeyController(did DID) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidKeyController, "Invalid key controller: %v", did)
 }
 
-func ErrVeriMethodKeyTypeNotImplemented(keyType KeyType) sdk.Error {
-	return sdk.NewError(DefaultCodespace, CodeVeriMethodKeyTypeNotImplemented, "Verification not implemented with key type: %v", keyType)
+func ErrVerificationMethodKeyTypeNotImplemented(keyType KeyType) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeVerificationMethodKeyTypeNotImplemented, "Verification not implemented with key type: %v", keyType)
 }

--- a/x/did/types/msgs.go
+++ b/x/did/types/msgs.go
@@ -12,21 +12,21 @@ var (
 
 // MsgCreateDID defines a CreateDID message.
 type MsgCreateDID struct {
-	DID          DID            `json:"did"`
-	Document     DIDDocument    `json:"document"`
-	VeriMethodID VeriMethodID   `json:"verification_method_id"`
-	Signature    []byte         `json:"signature"`
-	FromAddress  sdk.AccAddress `json:"from_address"`
+	DID                  DID                  `json:"did"`
+	Document             DIDDocument          `json:"document"`
+	VerificationMethodID VerificationMethodID `json:"verification_method_id"`
+	Signature            []byte               `json:"signature"`
+	FromAddress          sdk.AccAddress       `json:"from_address"`
 }
 
 // NewMsgCreateDID is a constructor of MsgCreateDID.
-func NewMsgCreateDID(did DID, doc DIDDocument, veriMethodID VeriMethodID, sig []byte, fromAddr sdk.AccAddress) MsgCreateDID {
+func NewMsgCreateDID(did DID, doc DIDDocument, verificationMethodID VerificationMethodID, sig []byte, fromAddr sdk.AccAddress) MsgCreateDID {
 	return MsgCreateDID{
-		DID:          did,
-		Document:     doc,
-		VeriMethodID: veriMethodID,
-		Signature:    sig,
-		FromAddress:  fromAddr,
+		DID:                  did,
+		Document:             doc,
+		VerificationMethodID: verificationMethodID,
+		Signature:            sig,
+		FromAddress:          fromAddr,
 	}
 }
 
@@ -65,21 +65,21 @@ func (msg MsgCreateDID) GetSigners() []sdk.AccAddress {
 
 // MsgUpdateDID defines a UpdateDID message.
 type MsgUpdateDID struct {
-	DID          DID            `json:"did"`
-	Document     DIDDocument    `json:"document"`
-	VeriMethodID VeriMethodID   `json:"verification_method_id"`
-	Signature    []byte         `json:"signature"`
-	FromAddress  sdk.AccAddress `json:"from_address"`
+	DID                  DID                  `json:"did"`
+	Document             DIDDocument          `json:"document"`
+	VerificationMethodID VerificationMethodID `json:"verification_method_id"`
+	Signature            []byte               `json:"signature"`
+	FromAddress          sdk.AccAddress       `json:"from_address"`
 }
 
 // NewMsgUpdateDID is a constructor of MsgUpdateDID.
-func NewMsgUpdateDID(did DID, doc DIDDocument, veriMethodID VeriMethodID, sig []byte, fromAddr sdk.AccAddress) MsgUpdateDID {
+func NewMsgUpdateDID(did DID, doc DIDDocument, verificationMethodID VerificationMethodID, sig []byte, fromAddr sdk.AccAddress) MsgUpdateDID {
 	return MsgUpdateDID{
-		DID:          did,
-		Document:     doc,
-		VeriMethodID: veriMethodID,
-		Signature:    sig,
-		FromAddress:  fromAddr,
+		DID:                  did,
+		Document:             doc,
+		VerificationMethodID: verificationMethodID,
+		Signature:            sig,
+		FromAddress:          fromAddr,
 	}
 }
 
@@ -118,15 +118,15 @@ func (msg MsgUpdateDID) GetSigners() []sdk.AccAddress {
 
 // MsgDeactivateDID defines a UpdateDID message.
 type MsgDeactivateDID struct {
-	DID          DID            `json:"did"`
-	VeriMethodID VeriMethodID   `json:"verification_method_id"`
-	Signature    []byte         `json:"signature"`
-	FromAddress  sdk.AccAddress `json:"from_address"`
+	DID                  DID                  `json:"did"`
+	VerificationMethodID VerificationMethodID `json:"verification_method_id"`
+	Signature            []byte               `json:"signature"`
+	FromAddress          sdk.AccAddress       `json:"from_address"`
 }
 
 // NewMsgDeactivateDID is a constructor of MsgDeactivateDID.
-func NewMsgDeactivateDID(did DID, veriMethodID VeriMethodID, sig []byte, fromAddr sdk.AccAddress) MsgDeactivateDID {
-	return MsgDeactivateDID{did, veriMethodID, sig, fromAddr}
+func NewMsgDeactivateDID(did DID, verificationMethodID VerificationMethodID, sig []byte, fromAddr sdk.AccAddress) MsgDeactivateDID {
+	return MsgDeactivateDID{did, verificationMethodID, sig, fromAddr}
 }
 
 // Route returns the name of the module.

--- a/x/did/types/msgs_test.go
+++ b/x/did/types/msgs_test.go
@@ -23,10 +23,10 @@ func TestMsgCreateDID(t *testing.T) {
 	sig := []byte("my-sig")
 	fromAddr := getFromAddress(t)
 
-	msg := types.NewMsgCreateDID(doc.ID, doc, doc.VeriMethods[0].ID, sig, fromAddr)
+	msg := types.NewMsgCreateDID(doc.ID, doc, doc.VerificationMethods[0].ID, sig, fromAddr)
 	require.Equal(t, doc.ID, msg.DID)
 	require.Equal(t, doc, msg.Document)
-	require.Equal(t, doc.VeriMethods[0].ID, msg.VeriMethodID)
+	require.Equal(t, doc.VerificationMethods[0].ID, msg.VerificationMethodID)
 	require.Equal(t, sig, msg.Signature)
 	require.Equal(t, fromAddr, msg.FromAddress)
 
@@ -37,7 +37,7 @@ func TestMsgCreateDID(t *testing.T) {
 	require.Equal(t, fromAddr, msg.GetSigners()[0])
 
 	require.Equal(t,
-		`{"type":"did/MsgCreateDID","value":{"did":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","document":{"@context":"https://www.w3.org/ns/did/v1","authentication":["did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1"],"id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","verificationMethod":[{"controller":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"EcdsaSecp256k1VerificationKey2019"}]},"from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","signature":"bXktc2ln","verification_method_id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1"}}`,
+		`{"type":"did/MsgCreateDID","value":{"did":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","document":{"@context":"https://www.w3.org/ns/did/v1","assertionMethod":[{"controller":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key2","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"EcdsaSecp256k1VerificationKey2019"}],"authentication":["did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1"],"id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","service":[{"id":"service1","serviceEndpoint":"https://example.org","type":"LinkedDomains"}],"verificationMethod":[{"controller":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"EcdsaSecp256k1VerificationKey2019"}]},"from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","signature":"bXktc2ln","verification_method_id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1"}}`,
 		string(msg.GetSignBytes()),
 	)
 }
@@ -47,10 +47,10 @@ func TestMsgUpdateDID(t *testing.T) {
 	sig := []byte("my-sig")
 	fromAddr := getFromAddress(t)
 
-	msg := types.NewMsgUpdateDID(doc.ID, doc, doc.VeriMethods[0].ID, sig, fromAddr)
+	msg := types.NewMsgUpdateDID(doc.ID, doc, doc.VerificationMethods[0].ID, sig, fromAddr)
 	require.Equal(t, doc.ID, msg.DID)
 	require.Equal(t, doc, msg.Document)
-	require.Equal(t, doc.VeriMethods[0].ID, msg.VeriMethodID)
+	require.Equal(t, doc.VerificationMethods[0].ID, msg.VerificationMethodID)
 	require.Equal(t, sig, msg.Signature)
 	require.Equal(t, fromAddr, msg.FromAddress)
 
@@ -61,7 +61,7 @@ func TestMsgUpdateDID(t *testing.T) {
 	require.Equal(t, fromAddr, msg.GetSigners()[0])
 
 	require.Equal(t,
-		`{"type":"did/MsgUpdateDID","value":{"did":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","document":{"@context":"https://www.w3.org/ns/did/v1","authentication":["did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1"],"id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","verificationMethod":[{"controller":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"EcdsaSecp256k1VerificationKey2019"}]},"from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","signature":"bXktc2ln","verification_method_id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1"}}`,
+		`{"type":"did/MsgUpdateDID","value":{"did":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","document":{"@context":"https://www.w3.org/ns/did/v1","assertionMethod":[{"controller":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key2","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"EcdsaSecp256k1VerificationKey2019"}],"authentication":["did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1"],"id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","service":[{"id":"service1","serviceEndpoint":"https://example.org","type":"LinkedDomains"}],"verificationMethod":[{"controller":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm","id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1","publicKeyBase58":"qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b","type":"EcdsaSecp256k1VerificationKey2019"}]},"from_address":"panacea154p6kyu9kqgvcmq63w3vpn893ssy6anpu8ykfq","signature":"bXktc2ln","verification_method_id":"did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm#key1"}}`,
 		string(msg.GetSignBytes()),
 	)
 }
@@ -71,9 +71,9 @@ func TestDeactivateDID(t *testing.T) {
 	sig := []byte("my-sig")
 	fromAddr := getFromAddress(t)
 
-	msg := types.NewMsgDeactivateDID(doc.ID, doc.VeriMethods[0].ID, sig, fromAddr)
+	msg := types.NewMsgDeactivateDID(doc.ID, doc.VerificationMethods[0].ID, sig, fromAddr)
 	require.Equal(t, doc.ID, msg.DID)
-	require.Equal(t, doc.VeriMethods[0].ID, msg.VeriMethodID)
+	require.Equal(t, doc.VerificationMethods[0].ID, msg.VerificationMethodID)
 	require.Equal(t, sig, msg.Signature)
 	require.Equal(t, fromAddr, msg.FromAddress)
 
@@ -97,13 +97,31 @@ func getFromAddress(t *testing.T) sdk.AccAddress {
 
 func newDIDDocument() types.DIDDocument {
 	did, _ := types.ParseDID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
-	veriMethodID := types.NewVeriMethodID(did, "key1")
+	verificationMethodID := types.NewVerificationMethodID(did, "key1")
 	pubKey, _ := secp256k1util.PubKeyFromBase58("qoRmLNBEXoaKDE8dKffMq2DBNxacTEfvbKRuFrccYW1b")
-	veriMethods := []types.VeriMethod{
-		types.NewVeriMethod(veriMethodID, types.ES256K_2019, did, secp256k1util.PubKeyBytes(pubKey)),
+	verificationMethods := []types.VerificationMethod{
+		types.NewVerificationMethod(verificationMethodID, types.ES256K_2019, did, secp256k1util.PubKeyBytes(pubKey)),
 	}
-	authentications := []types.Authentication{
-		types.NewAuthentication(veriMethods[0].ID),
+	authentications := []types.VerificationRelationship{
+		types.NewVerificationRelationship(verificationMethods[0].ID),
 	}
-	return types.NewDIDDocument(did, veriMethods, authentications)
+	assertionMethods := []types.VerificationRelationship{
+		types.NewVerificationRelationshipDedicated(
+			types.NewVerificationMethod(
+				types.NewVerificationMethodID(did, "key2"),
+				types.ES256K_2019, did, secp256k1util.PubKeyBytes(pubKey),
+			),
+		),
+	}
+	services := []types.Service{
+		types.NewService("service1", "LinkedDomains", "https://example.org"),
+	}
+
+	return types.NewDIDDocument(
+		did,
+		types.WithVerificationMethods(verificationMethods),
+		types.WithAuthentications(authentications),
+		types.WithAssertionMethods(assertionMethods),
+		types.WithServices(services),
+	)
 }


### PR DESCRIPTION
Closes #48 

- Now, DID Document can contain (according to [the semi-finalized new DID spec](https://www.w3.org/TR/did-core/))
  - `controller`
  - `service`
  - `assertionMethod`: essential for VC/VP verification using the [vc-service](https://github.com/medibloc/vc-service)
  - `keyAgreement`
  - `capabilityInvocation`
  - `capabilityDelegation`