### PR TITLE
x/did: Fix checking if VerificationRelationships are valid

### DIFF
--- a/x/did/handler.go
+++ b/x/did/handler.go
@@ -91,7 +91,7 @@ func handleMsgDeactivateDID(ctx sdk.Context, keeper keeper.Keeper, msg MsgDeacti
 // A public key is taken from one of verificationMethods in the DID Document.
 // If the verification is successful, it returns a new sequence. If not, it returns an error.
 func verifyDIDOwnership(data types.Signable, seq types.Sequence, doc types.DIDDocument, verificationMethodID types.VerificationMethodID, sig []byte) (types.Sequence, sdk.Error) {
-	verificationMethod, ok := doc.VerificationMethodByID(verificationMethodID)
+	verificationMethod, ok := doc.VerificationMethodFrom(doc.Authentications, verificationMethodID)
 	if !ok {
 		return 0, types.ErrVerificationMethodIDNotFound(verificationMethodID)
 	}

--- a/x/did/types/did_test.go
+++ b/x/did/types/did_test.go
@@ -98,8 +98,7 @@ func TestDIDDocument_VerificationMethodByID(t *testing.T) {
 	pubKey := secp256k1util.PubKeyBytes(secp256k1util.DerivePubKey(secp256k1.GenPrivKey()))
 	verificationMethodID := NewVerificationMethodID(did, "key1")
 	verificationMethods := []VerificationMethod{NewVerificationMethod(verificationMethodID, ES256K_2019, did, pubKey)}
-	authentications := []VerificationRelationship{NewVerificationRelationship(verificationMethods[0].ID)}
-	doc := NewDIDDocument(did, WithVerificationMethods(verificationMethods), WithAuthentications(authentications))
+	doc := NewDIDDocument(did, WithVerificationMethods(verificationMethods))
 
 	found, ok := doc.VerificationMethodByID(verificationMethodID)
 	require.True(t, ok)
@@ -107,9 +106,25 @@ func TestDIDDocument_VerificationMethodByID(t *testing.T) {
 
 	_, ok = doc.VerificationMethodByID(NewVerificationMethodID(did, "key2"))
 	require.False(t, ok)
+}
+
+func TestDIDDocument_VerificationMethodFrom(t *testing.T) {
+	did := DID("did:panacea:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm")
+	pubKey := secp256k1util.PubKeyBytes(secp256k1util.DerivePubKey(secp256k1.GenPrivKey()))
+	verificationMethodID := NewVerificationMethodID(did, "key1")
+	verificationMethods := []VerificationMethod{NewVerificationMethod(verificationMethodID, ES256K_2019, did, pubKey)}
+	authentications := []VerificationRelationship{NewVerificationRelationship(verificationMethods[0].ID)}
+	doc := NewDIDDocument(did, WithVerificationMethods(verificationMethods), WithAuthentications(authentications))
+
+	found, ok := doc.VerificationMethodFrom(doc.Authentications, verificationMethodID)
+	require.True(t, ok)
+	require.Equal(t, verificationMethods[0], found)
+
+	_, ok = doc.VerificationMethodFrom(doc.Authentications, NewVerificationMethodID(did, "key2"))
+	require.False(t, ok)
 
 	doc.Authentications = []VerificationRelationship{} // clear authentications
-	_, ok = doc.VerificationMethodByID(verificationMethodID)
+	_, ok = doc.VerificationMethodFrom(doc.Authentications, verificationMethodID)
 	require.False(t, ok)
 }
 


### PR DESCRIPTION
Previously, the role of `VerificationMethodByID(id)` was:
- Find a `authentication` from the DID Document
- Find a corresponding `verificationMethod` which has the same ID as the `authentication`.

It was used for the `DIDDocument.Valid()`. But, if the DID Document has `assertionMethod`s, not `authentication`s, the `VerificationMethodByID(id)` returns 'not found'.
```json
{
  "verificationMethod": [{
    "id": "key1",
    "publicKeyBase58": "asdgkadjspoiejflkadskjfa",
  }],
  "assertionMethod": [
    "key1"
  ]
}
```

So, the function should be split for various use cases.
- `VerificationMethodByID(id)`
  - Find a `verificationMethod` by its ID from the DID Document
- `VerificationMethodFrom(verificationRelationships, ID)`
  - Find a `verificationRelationship` from the DID Document
  - Find a corresponding `verificationMethod` which has the same ID as the `verificationRelationship`.

The 1st one is used in the `DIDDocument.Valid()`.
The 2nd one is used in the `verifyDIDOwnership()` which traverses the `authentication` list.
