### PR TITLE
starport: Change Makefile to build only `panacead`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,6 @@ lint:
 
 build: go.sum
 	go build -mod=readonly $(BUILD_FLAGS) -o build/panacead ./cmd/panacead
-	go build -mod=readonly $(BUILD_FLAGS) -o build/panaceacli ./cmd/panaceacli
-	go build -mod=readonly $(BUILD_FLAGS) -o build/panaceakeyutil ./cmd/panaceakeyutil
 
 test:
 	mkdir -p $(ARTIFACT_DIR)
@@ -57,8 +55,6 @@ update_panacea_lite_docs:
 
 install: go.sum update_panacea_lite_docs
 	go install -mod=readonly $(BUILD_FLAGS) ./cmd/panacead
-	go install -mod=readonly $(BUILD_FLAGS) ./cmd/panaceacli
-	go install -mod=readonly $(BUILD_FLAGS) ./cmd/panaceakeyutil
 
 ########################################
 ### Tools & dependencies

--- a/app/prefix.go
+++ b/app/prefix.go
@@ -18,6 +18,8 @@ var (
 
 func SetConfig() {
 	config := sdk.GetConfig()
+	config.SetCoinType(371)
+	config.SetFullFundraiserPath("44'/371'/0'/0/0")
 	config.SetBech32PrefixForAccount(AccountAddressPrefix, AccountPubKeyPrefix)
 	config.SetBech32PrefixForValidator(ValidatorAddressPrefix, ValidatorPubKeyPrefix)
 	config.SetBech32PrefixForConsensusNode(ConsNodeAddressPrefix, ConsNodePubKeyPrefix)

--- a/cmd/panacead/cmd/root.go
+++ b/cmd/panacead/cmd/root.go
@@ -265,7 +265,9 @@ func overwriteFlagDefaults(c *cobra.Command, defaults map[string]string) {
 	set := func(s *pflag.FlagSet, key, val string) {
 		if f := s.Lookup(key); f != nil {
 			f.DefValue = val
-			f.Value.Set(val)
+			if err := f.Value.Set(val); err != nil {
+				panic(err)
+			}
 		}
 	}
 	for key, val := range defaults {

--- a/x/panacea/client/rest/rest.go
+++ b/x/panacea/client/rest/rest.go
@@ -16,10 +16,14 @@ func RegisterRoutes(clientCtx client.Context, r *mux.Router) {
 	// this line is used by starport scaffolding # 2
 }
 
+//TODO: enable lint
+//nolint:unused,deadcode
 func registerQueryRoutes(clientCtx client.Context, r *mux.Router) {
 	// this line is used by starport scaffolding # 3
 }
 
+//TODO: enable lint
+//nolint:unused,deadcode
 func registerTxHandlers(clientCtx client.Context, r *mux.Router) {
 	// this line is used by starport scaffolding # 4
 }


### PR DESCRIPTION
From Stargate, we will have only one binary: `panacead`.

CI should work from this PR.