### PR TITLE
docs: Fix `create-validator` guide and Add `edit-validator` guide

### DIFF
--- a/.gitbook/guide/interaction-with-the-network-cli.md
+++ b/.gitbook/guide/interaction-with-the-network-cli.md
@@ -268,7 +268,7 @@ panaceacli tx staking create-validator \
   --commission-rate="0.10" \
   --commission-max-rate="0.20" \
   --commission-max-change-rate="0.01" \
-  --min-self-delegation="1000000" \
+  --min-self-delegation="1" \
   --amount=10000000umed \
   --fees="1000000umed" \
   --from=<key-name>

--- a/.gitbook/guide/interaction-with-the-network-cli.md
+++ b/.gitbook/guide/interaction-with-the-network-cli.md
@@ -268,7 +268,7 @@ panaceacli tx staking create-validator \
   --commission-rate="0.10" \
   --commission-max-rate="0.20" \
   --commission-max-change-rate="0.01" \
-  --min-self-delegation="1" \
+  --min-self-delegation="1000000" \
   --amount=10000000umed \
   --fees="1000000umed" \
   --from=<key-name>
@@ -284,10 +284,12 @@ panaceacli tx staking create-validator \
 - `commission-max-change-rate`: A maximum daily increase of the validator commission. This cannot be changed after the
   `create-validator` transaction is processed. This is used to measure % point change over the `commision-rate`.
   E.g. 1% to 2% is a 100% rate increase, but only 1% point.
-- `min-self-delegation`: A strictly positive integer that represents the minimum amount of self-delegated voting power
-  your validator must always have. A `min-self-delegation` of `1` means your validator will never have a self-delegation
-  lower than `1med` (`1000000umed`).
+- `min-self-delegation`: A strictly positive integer in `umed` that represents the minimum amount of self-delegated voting power
+  your validator must always have. If the validator's self-delegated stake falls below this limit, their entire staking pool will unbond.
 - `amount`: An amount of your self-delegation
+
+**Note:** A minimum amount of MEDs that must be delegated to be an active validator is `1med` (`1000000umed`).
+In other words, validators cannot be in the active set, if their total stake (= self-bonded stake + delegators stake) is under `1med`.
 
 You can confirm that you are in the validator set by the following command:
 ```bash
@@ -322,7 +324,7 @@ panaceacli tx staking edit-validator
   --fees="1000000umed"
 ```
 
-**Note**: The commission-rate value must adhere to the following invariants:
+**Note**: The `--commission-rate` value must adhere to the following invariants:
 
 - Must be between 0 and the validator's `commission-max-rate`
 - Must not exceed the validator's `commission-max-change-rate` which is maximum % point change rate **per day**.

--- a/.gitbook/guide/interaction-with-the-network-cli.md
+++ b/.gitbook/guide/interaction-with-the-network-cli.md
@@ -306,17 +306,10 @@ if the field has never been set or remain the same if it has been set in the pas
 
 The `--from` option specifies which validator you are editing.
 
-The `--identity` can be used as to verify identity with systems like Keybase or UPort.
-When using with Keybase, `--identity` should be populated with a 16-digit string that is generated with a [keybase.io](https://keybase.io/) account.
-It's a cryptographically secure method of verifying your identity across multiple online networks.
-The Keybase API allows us to retrieve your Keybase avatar.
-This is how you can add a logo to your validator profile.
-
 ```bash
 panaceacli tx staking edit-validator
   --moniker="choose a new moniker" \
   --website="https://example.com" \
-  --identity=6A0D65E29A4CBC8E \
   --details="This is a detail description" \
   --chain-id=<chain_id> \
   --commission-rate="0.15" \

--- a/.gitbook/guide/interaction-with-the-network-cli.md
+++ b/.gitbook/guide/interaction-with-the-network-cli.md
@@ -279,9 +279,9 @@ panaceacli tx staking create-validator \
   For details about various key types, please see this [guide](interaction-with-the-network-cli.md#keys).
 - `moniker`: A validator nickname that will be displayed publicly
 - `commission-rate`: An initial commission rate on block rewards and fees charged to delegators
-- `commission-max-rate`: A maximum commission rate which this validator can charge. This can be changed after the
+- `commission-max-rate`: A maximum commission rate which this validator can charge. This cannot be changed after the
   `create-validator` transaction is processed.
-- `commission-max-change-rate`: A maximum daily increase of the validator commission. This can be changed after the
+- `commission-max-change-rate`: A maximum daily increase of the validator commission. This cannot be changed after the
   `create-validator` transaction is processed. This is used to measure % point change over the `commision-rate`.
   E.g. 1% to 2% is a 100% rate increase, but only 1% point.
 - `min-self-delegation`: A strictly positive integer that represents the minimum amount of self-delegated voting power
@@ -293,6 +293,40 @@ You can confirm that you are in the validator set by the following command:
 ```bash
 panaceacli query staking validators
 ```
+
+### Edit validator description
+
+You can edit your validator's public description. This info is to identify your validator,
+and will be relied on by delegators to decide which validators to stake to.
+Make sure to provide input for every flag below.
+If a flag is not included in the command the field will default to empty (`--moniker` defaults to the machine name)
+if the field has never been set or remain the same if it has been set in the past.
+
+The `--from` option specifies which validator you are editing.
+
+The `--identity` can be used as to verify identity with systems like Keybase or UPort.
+When using with Keybase, `--identity` should be populated with a 16-digit string that is generated with a [keybase.io](https://keybase.io/) account.
+It's a cryptographically secure method of verifying your identity across multiple online networks.
+The Keybase API allows us to retrieve your Keybase avatar.
+This is how you can add a logo to your validator profile.
+
+```bash
+panaceacli tx staking edit-validator
+  --moniker="choose a new moniker" \
+  --website="https://example.com" \
+  --identity=6A0D65E29A4CBC8E \
+  --details="This is a detail description" \
+  --chain-id=<chain_id> \
+  --commission-rate="0.15" \
+  --from=<key_name> \
+  --fees="1000000umed"
+```
+
+**Note**: The commission-rate value must adhere to the following invariants:
+
+- Must be between 0 and the validator's `commission-max-rate`
+- Must not exceed the validator's `commission-max-change-rate` which is maximum % point change rate **per day**.
+  In other words, a validator can only change its commission once per day and within `commission-max-change-rate` bounds.
 
 ### Delegate to a Validator
 


### PR DESCRIPTION
- Fixed wrong option descriptions of the `create-validator` CLI command.
- Add a new guide for the `edit-validator` CLI command.