### PR TITLE
feat: stargate: Add more cosmos/base proto dependencies

### DIFF
--- a/protodep.lock
+++ b/protodep.lock
@@ -8,8 +8,8 @@ proto_outdir = "./third_party/proto"
   protocol = ""
 
 [[dependencies]]
-  target = "github.com/cosmos/cosmos-sdk/proto/cosmos/base/query/v1beta1"
+  target = "github.com/cosmos/cosmos-sdk/proto/cosmos/base"
   revision = "c4864e9f85011b3e971885ea995a0021c01a885d"
   branch = ""
-  path = "cosmos/base/query/v1beta1"
+  path = "cosmos/base"
   protocol = ""

--- a/protodep.toml
+++ b/protodep.toml
@@ -5,6 +5,6 @@ proto_outdir = "./third_party/proto"
     revision = "v0.42.4"
 
 [[dependencies]]
-    target = "github.com/cosmos/cosmos-sdk/proto/cosmos/base/query/v1beta1"
-    path = "cosmos/base/query/v1beta1"
+    target = "github.com/cosmos/cosmos-sdk/proto/cosmos/base"
+    path = "cosmos/base"
     revision = "v0.42.4"


### PR DESCRIPTION
So far, we've used the only `cosmos/base/query/v1beta1/pagniation.proto`. But, we need to use other `cosmos/base/**/*.proto` files, such as `cosmos/base/v1beta1/coin.proto`.

Thus, let's fetch all of `cosmos/base/**/*.proto` files as dependencies. Later, we can minimize them.