### PR TITLE
feat: stargate: Add the default genesis overriding

### DIFF
--- a/cmd/panacead/cmd/init.go
+++ b/cmd/panacead/cmd/init.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	tmjson "github.com/tendermint/tendermint/libs/json"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
+	"github.com/medibloc/panacea-core/app"
+	"github.com/medibloc/panacea-core/types/assets"
+	"github.com/spf13/cobra"
+	"github.com/tendermint/tendermint/types"
+)
+
+// InitCmd wraps the genutilcli.InitCmd to inject specific parameters for Panacea.
+// It reads the default genesis.json, modifies and exports it.
+// Reference: https://github.com/public-awesome/stargaze/blob/b92bf9847559b9c7f4ac08576d056d3d00efe12c/cmd/starsd/cmd/init.go
+func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
+	initCmd := genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome)
+	initCmd.PostRunE = func(cmd *cobra.Command, args []string) error {
+		clientCtx := client.GetClientContextFromCmd(cmd)
+		cdc := clientCtx.JSONMarshaler
+
+		serverCtx := server.GetServerContextFromCmd(cmd)
+		config := serverCtx.Config
+
+		config.SetRoot(clientCtx.HomeDir)
+
+		genFile := config.GenesisFile()
+		genDoc := &types.GenesisDoc{}
+
+		if _, err := os.Stat(genFile); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+		} else {
+			genDoc, err = types.GenesisDocFromFile(genFile)
+			if err != nil {
+				return fmt.Errorf("failed to read genesis file: %w", err)
+			}
+		}
+
+		appState, err := overrideGenesis(cdc, genDoc)
+		if err != nil {
+			return fmt.Errorf("failed to override genesis: %w", err)
+		}
+
+		genDoc.AppState = appState
+		if err := genutil.ExportGenesisFile(genDoc, genFile); err != nil {
+			return fmt.Errorf("failed to export genesis file: %w", err)
+		}
+
+		return nil
+	}
+
+	return initCmd
+}
+
+// overrideGenesis overrides some parameters in the genesis doc to the panacea-specific values.
+func overrideGenesis(cdc codec.JSONMarshaler, genDoc *types.GenesisDoc) (json.RawMessage, error) {
+	appState := make(map[string]json.RawMessage)
+	if err := tmjson.Unmarshal(genDoc.AppState, &appState); err != nil {
+		return nil, fmt.Errorf("failed to JSON unmarshal initial genesis state %w", err)
+	}
+
+	var stakingGenState stakingtypes.GenesisState
+	if err := cdc.UnmarshalJSON(appState[stakingtypes.ModuleName], &stakingGenState); err != nil {
+		return nil, err
+	}
+	stakingGenState.Params.UnbondingTime = time.Second * 60 * 60 * 24 * 7 * 3 // three weeks
+	stakingGenState.Params.MaxValidators = 50
+	stakingGenState.Params.BondDenom = assets.MicroMedDenom
+	appState[stakingtypes.ModuleName] = cdc.MustMarshalJSON(&stakingGenState)
+
+	var mintGenState minttypes.GenesisState
+	if err := cdc.UnmarshalJSON(appState[minttypes.ModuleName], &mintGenState); err != nil {
+		return nil, err
+	}
+	mintGenState.Minter = minttypes.InitialMinter(sdk.NewDecWithPrec(7, 2)) // 7% inflation
+	mintGenState.Params.MintDenom = assets.MicroMedDenom
+	mintGenState.Params.InflationRateChange = sdk.NewDecWithPrec(3, 2) // 3%
+	mintGenState.Params.InflationMin = sdk.NewDecWithPrec(7, 2)        // 7%
+	mintGenState.Params.InflationMax = sdk.NewDecWithPrec(10, 2)       // 10%
+	mintGenState.Params.BlocksPerYear = uint64(60 * 60 * 24 * 365.25)  // assuming 1 second block time
+	appState[minttypes.ModuleName] = cdc.MustMarshalJSON(&mintGenState)
+
+	var distrGenState distrtypes.GenesisState
+	if err := cdc.UnmarshalJSON(appState[distrtypes.ModuleName], &distrGenState); err != nil {
+		return nil, err
+	}
+	distrGenState.Params.CommunityTax = sdk.ZeroDec()
+	appState[distrtypes.ModuleName] = cdc.MustMarshalJSON(&distrGenState)
+
+	var govGenState govtypes.GenesisState
+	if err := cdc.UnmarshalJSON(appState[govtypes.ModuleName], &govGenState); err != nil {
+		return nil, err
+	}
+	minDepositTokens := sdk.TokensFromConsensusPower(100000) // 100,000 MED
+	govGenState.DepositParams.MinDeposit = sdk.Coins{sdk.NewCoin(assets.MicroMedDenom, minDepositTokens)}
+	govGenState.DepositParams.MaxDepositPeriod = 60 * 60 * 24 * 14 * time.Second // 14 days
+	govGenState.VotingParams.VotingPeriod = 60 * 60 * 24 * 14 * time.Second      // 14 days
+	appState[govtypes.ModuleName] = cdc.MustMarshalJSON(&govGenState)
+
+	var crisisGenState crisistypes.GenesisState
+	if err := cdc.UnmarshalJSON(appState[crisistypes.ModuleName], &crisisGenState); err != nil {
+		return nil, err
+	}
+	crisisGenState.ConstantFee = sdk.NewCoin(assets.MicroMedDenom, sdk.NewInt(1000000000000)) // Spend 1,000,000 MED for invariants check
+	appState[crisistypes.ModuleName] = cdc.MustMarshalJSON(&crisisGenState)
+
+	var slashingGenState slashingtypes.GenesisState
+	if err := cdc.UnmarshalJSON(appState[slashingtypes.ModuleName], &slashingGenState); err != nil {
+		return nil, err
+	}
+	slashingGenState.Params.SignedBlocksWindow = 10000
+	slashingGenState.Params.MinSignedPerWindow = sdk.NewDecWithPrec(5, 2)
+	slashingGenState.Params.SlashFractionDoubleSign = sdk.NewDecWithPrec(5, 2) // 5%
+	slashingGenState.Params.SlashFractionDowntime = sdk.NewDecWithPrec(1, 4)   // 0.01%
+	appState[slashingtypes.ModuleName] = cdc.MustMarshalJSON(&slashingGenState)
+
+	return tmjson.Marshal(appState)
+}

--- a/cmd/panacead/cmd/root.go
+++ b/cmd/panacead/cmd/root.go
@@ -58,7 +58,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 
 	rootCmd := &cobra.Command{
 		Use:   app.Name + "d",
-		Short: "Stargate CosmosHub App",
+		Short: "Panacea App",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
 				return err
@@ -81,7 +81,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	authclient.Codec = encodingConfig.Marshaler
 
 	rootCmd.AddCommand(
-		genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
+		InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
 		genutilcli.MigrateGenesisCmd(),
 		genutilcli.GenTxCmd(app.ModuleBasics, encodingConfig.TxConfig, banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),

--- a/types/assets/assets.go
+++ b/types/assets/assets.go
@@ -1,0 +1,7 @@
+package assets
+
+const (
+	MicroMedDenom = "umed"
+
+	MicroUnit = int64(1e6)
+)


### PR DESCRIPTION
When running `panacead init ...`, the Cosmos generates a genesis with default params that are defined in each `x/*` modules (`stake` coin denom, and so on...).
So, it's annoying to modify the generated `genesis.json` every time after running `panacead init ...`.

Thus, let's override it.

Actually, we've had this overriding logic so far: https://github.com/medibloc/panacea-core/blob/985271f795c2ff0bf1f6b63152d97fabb41dbfa2/init/init.go

In this PR, I made it work in Stargate by referring to https://github.com/public-awesome/stargaze/blob/b92bf9847559b9c7f4ac08576d056d3d00efe12c/cmd/starsd/cmd/init.go.