### PR TITLE
docs: stargate: Update the `deploy-a-testnet` doc for Stargate

### DIFF
--- a/.gitbook/guide/deploy-a-testnet.md
+++ b/.gitbook/guide/deploy-a-testnet.md
@@ -15,15 +15,15 @@ This document describes 2 ways to setup a network of `panacead` nodes.
 panacead init node1 --chain-id=testing
 
 # Create a key to hold your validator account
-panaceacli keys add validator
+panacead keys add validator
 
 # Add that key into the genesis.app_state.accounts array in the genesis file
 # NOTE: this command lets you set the number of coins. Make sure this account has some coins
 # with the genesis.app_state.staking.params.bond_denom denom.
-panacead add-genesis-account $(panaceacli keys show validator -a) 100000000000000umed
+panacead add-genesis-account $(panacead keys show validator -a) 100000000000000umed
 
 # Generate the transaction that creates your validator
-panacead gentx --name validator --amount 1000000000000umed --commission-rate 0.1 --commission-max-rate 0.2 --commission-max-change-rate 0.01  --min-self-delegation 1000000
+panacead gentx validator 1000000000000umed --commission-rate 0.1 --commission-max-rate 0.2 --commission-max-change-rate 0.01  --min-self-delegation 1000000 --chain-id testing
 
 # Add the generated bonding transaction to the genesis file
 panacead collect-gentxs
@@ -31,9 +31,8 @@ panacead collect-gentxs
 # Now its safe to start `panacead`
 panacead start
 ```
-This setup puts all the data for `panacead` in `~/.panacead`.
-You can examine the genesis file that you created at `~/.panacead/config/genesis.json`.
-With this configuration, `panaceacli` is also ready to use and has an account with tokens.
+This setup puts all the data for `panacead` in `~/.panacea`.
+You can examine the genesis file that you created at `~/.panacea/config/genesis.json`.
 
 ### Deploy the second node
 
@@ -42,7 +41,7 @@ Init the second node using another moniker: `node2`.
 panacead init node2 --chain-id=testing
 ```
 
-Overwrite `~/.panacead/config/genesis.json` with the first node's `genesis.json`.
+Overwrite `~/.panacea/config/genesis.json` with the first node's `genesis.json`.
 
 Get a node ID of the first node.
 ```bash
@@ -50,7 +49,7 @@ panacead tendermint show-node-id
 > 46046c89ec576daa0662613ee0142ab61dd2421e
 ```
 
-Set a `persistent_peers` in the `~/.panacead/config/config.toml` of the second node.
+Set a `persistent_peers` in the `~/.panacea/config/config.toml` of the second node.
 ```toml
 # Comma separated list of nodes to keep persistent connections to
 persistent_peers = "<first_node_id>@<first_node_ip>:26656"


### PR DESCRIPTION
As we usually run a local node for testing Stargate manually, I just updated a `Deploy a Testnet` doc.
Other doc must be updated after the Stargate development is done.