### PR TITLE
feat: stargate: Add unit tests for `token`-related types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/tendermint/tendermint v0.34.9
 	github.com/tendermint/tm-db v0.6.4
 	google.golang.org/genproto v0.0.0-20210207032614-bba0dbe2a9ea

--- a/x/token/types/errors.go
+++ b/x/token/types/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrInvalidSymbol      = sdkerrors.Register(ModuleName, 3, "invalid symbol")
 	ErrInvalidTotalSupply = sdkerrors.Register(ModuleName, 4, "invalid total supply")
 	ErrTokenExists        = sdkerrors.Register(ModuleName, 5, "token already exists")
+	ErrInvalidDenom       = sdkerrors.Register(ModuleName, 6, "invalid denom")
 )

--- a/x/token/types/types.go
+++ b/x/token/types/types.go
@@ -77,6 +77,9 @@ func validateToken(t *Token) error {
 	if err := validateTotalSupplyAmount(t.TotalSupply.Amount); err != nil {
 		return err
 	}
+	if GetMicroDenom(t.Symbol) != t.TotalSupply.Denom {
+		return ErrInvalidDenom
+	}
 	if _, err := sdk.AccAddressFromBech32(t.OwnerAddress); err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid owner address (%s)", err)
 	}

--- a/x/token/types/types_test.go
+++ b/x/token/types/types_test.go
@@ -1,0 +1,116 @@
+package types
+
+import (
+	"os"
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount("panacea", "panaceapub")
+	config.Seal()
+
+	os.Exit(m.Run())
+}
+
+func TestNewSymbol(t *testing.T) {
+	symbol := NewSymbol("lov", "1234567890ABCDEFGHIJKLMNOPQRSTUXYZ")
+	require.Equal(t, "LOV-123", symbol)
+}
+
+func TestValidateName(t *testing.T) {
+	require.NoError(t, validateName("my name"))
+	require.ErrorIs(t, validateName(""), ErrInvalidName)
+
+	maxLenName := "12345678901234567890123456789012"
+	require.NoError(t, validateName(maxLenName))
+
+	require.ErrorIs(t, validateName(maxLenName+"X"), ErrInvalidName)
+}
+
+func TestValidateShortSymbol(t *testing.T) {
+	require.NoError(t, validateShortSymbol("lov"))
+
+	// if it's the same as MED (stake coin)
+	require.ErrorIs(t, validateShortSymbol("med"), ErrSymbolNotAllowed)
+	require.ErrorIs(t, validateShortSymbol("MED"), ErrSymbolNotAllowed)
+
+	require.ErrorIs(t, validateShortSymbol("2ov"), ErrInvalidSymbol)
+	require.ErrorIs(t, validateShortSymbol("Lo"), ErrInvalidSymbol)
+
+	maxLenSymbol := "A123456789012"
+	require.NoError(t, validateShortSymbol(maxLenSymbol))
+	require.ErrorIs(t, validateShortSymbol(maxLenSymbol+"X"), ErrInvalidSymbol)
+}
+
+func TestValidateSymbol(t *testing.T) {
+	require.NoError(t, validateSymbol("LoV-0eA"))
+	require.ErrorIs(t, validateSymbol("LoV0eA"), ErrInvalidSymbol)
+	require.ErrorIs(t, validateSymbol("LoV-0eAB"), ErrInvalidSymbol)
+}
+
+func TestValidateTotalSupplyAmount(t *testing.T) {
+	require.NoError(t, validateTotalSupplyAmount(sdk.NewInt(int64(100))))
+
+	// if not positive
+	require.ErrorIs(t, validateTotalSupplyAmount(sdk.NewInt(int64(0))), ErrInvalidTotalSupply)
+	require.ErrorIs(t, validateTotalSupplyAmount(sdk.NewInt(int64(-1))), ErrInvalidTotalSupply)
+
+	// regards to the max length
+	require.NoError(t, validateTotalSupplyAmount(sdk.NewInt(int64(90000000000000000))))
+	require.ErrorIs(t, validateTotalSupplyAmount(sdk.NewInt(int64(90000000000000000+1))), ErrInvalidTotalSupply)
+}
+
+func TestValidateToken(t *testing.T) {
+	require.NoError(t, validateToken(&Token{
+		Name:         "this is a name",
+		Symbol:       "LOV-0EA",
+		TotalSupply:  sdk.NewCoin("ulov0ea", sdk.NewInt(int64(100))),
+		OwnerAddress: "panacea1qzl3j4srlymax4urwxhfwv50y07jh3txtml7gk",
+	}))
+
+	require.ErrorIs(t, validateToken(&Token{
+		Name:         "", // invalid name
+		Symbol:       "LOV-0EA",
+		TotalSupply:  sdk.NewCoin("ulov0ea", sdk.NewInt(int64(100))),
+		OwnerAddress: "panacea1qzl3j4srlymax4urwxhfwv50y07jh3txtml7gk",
+	}), ErrInvalidName)
+
+	require.ErrorIs(t, validateToken(&Token{
+		Name:         "this is a name",
+		Symbol:       "", // invalid symbol
+		TotalSupply:  sdk.NewCoin("ulov0ea", sdk.NewInt(int64(100))),
+		OwnerAddress: "panacea1qzl3j4srlymax4urwxhfwv50y07jh3txtml7gk",
+	}), ErrInvalidSymbol)
+
+	require.ErrorIs(t, validateToken(&Token{
+		Name:         "this is a name",
+		Symbol:       "LOV-0EA",
+		TotalSupply:  sdk.NewCoin("ulov0ea", sdk.NewInt(int64(0))), // invalid total supply amount
+		OwnerAddress: "panacea1qzl3j4srlymax4urwxhfwv50y07jh3txtml7gk",
+	}), ErrInvalidTotalSupply)
+
+	require.ErrorIs(t, validateToken(&Token{
+		Name:         "this is a name",
+		Symbol:       "LOV-0EA",
+		TotalSupply:  sdk.NewCoin("ulov1ea", sdk.NewInt(int64(100))), // denom doesn't match with symbol
+		OwnerAddress: "panacea1qzl3j4srlymax4urwxhfwv50y07jh3txtml7gk",
+	}), ErrInvalidDenom)
+
+	require.ErrorIs(t, validateToken(&Token{
+		Name:         "this is a name",
+		Symbol:       "LOV-0EA",
+		TotalSupply:  sdk.NewCoin("ulov0ea", sdk.NewInt(int64(100))),
+		OwnerAddress: "INVALID", // invalid address
+	}), sdkerrors.ErrInvalidAddress)
+}
+
+func TestGetMicroDenom(t *testing.T) {
+	require.Equal(t, "ulov0ea", GetMicroDenom("LOV-0EA"))
+}


### PR DESCRIPTION
Just added simple tests that check `Token` type validation logics.

TODO:
- Test keeper, handler, and so on (by following [Cosmos' idea](https://github.com/cosmos/cosmos-sdk/blob/d7c5bc5f35505e1d64e9b3521067871947d55bfa/x/bank/keeper/keeper_test.go#L67), I guess)