### PR TITLE
fix: stargate: Support multi-signers in CLI (for `tx aol add-record`)

### DIFF
--- a/x/aol/client/cli/txRecord.go
+++ b/x/aol/client/cli/txRecord.go
@@ -1,7 +1,18 @@
 package cli
 
 import (
+	"bufio"
+	"fmt"
+	"os"
+
+	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+
+	"github.com/cosmos/cosmos-sdk/client/input"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -32,7 +43,8 @@ func CmdAddRecord() *cobra.Command {
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+
+			return generateOrBroadcastTxWithMultiSigners(clientCtx, cmd.Flags(), msg.GetSigners(), msg)
 		},
 	}
 
@@ -40,4 +52,166 @@ func CmdAddRecord() *cobra.Command {
 	cmd.Flags().String(flagFeePayer, "", "optional address to pay for the fee")
 
 	return cmd
+}
+
+// generateOrBroadcastTxWithMultiSigners is a fork of tx.GenerateOrBroadcastTxCLI, but with multi signers.
+func generateOrBroadcastTxWithMultiSigners(clientCtx client.Context, flagSet *pflag.FlagSet, signerAddrs []sdk.AccAddress, msgs ...sdk.Msg) error {
+	txf := tx.NewFactoryCLI(clientCtx, flagSet)
+	if txf.SignMode() == signing.SignMode_SIGN_MODE_UNSPECIFIED {
+		txf = txf.WithSignMode(signing.SignMode_SIGN_MODE_DIRECT)
+	}
+
+	if clientCtx.GenerateOnly {
+		return tx.GenerateTx(clientCtx, txf, msgs...)
+	}
+	return broadcastTxWithMultiSigners(clientCtx, txf, signerAddrs, msgs...)
+}
+
+// broadcastTxWithMultiSigners is a fork of tx.BroadcastTx, but with multi signers.
+func broadcastTxWithMultiSigners(clientCtx client.Context, txf tx.Factory, signerAddrs []sdk.AccAddress, msgs ...sdk.Msg) error {
+	if txf.SimulateAndExecute() || clientCtx.Simulate {
+		_, adjusted, err := tx.CalculateGas(clientCtx.QueryWithData, txf, msgs...)
+		if err != nil {
+			return err
+		}
+
+		txf = txf.WithGas(adjusted)
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", tx.GasEstimateResponse{GasEstimate: txf.Gas()})
+	}
+
+	if clientCtx.Simulate {
+		return nil
+	}
+
+	txBuilder, err := tx.BuildUnsignedTx(txf, msgs...)
+	if err != nil {
+		return err
+	}
+
+	if !clientCtx.SkipConfirm {
+		out, err := clientCtx.TxConfig.TxJSONEncoder()(txBuilder.GetTx())
+		if err != nil {
+			return err
+		}
+
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n\n", out)
+
+		buf := bufio.NewReader(os.Stdin)
+		ok, err := input.GetConfirmation("confirm transaction before signing and broadcasting", buf, os.Stderr)
+
+		if err != nil || !ok {
+			_, _ = fmt.Fprintf(os.Stderr, "%s\n", "cancelled transaction")
+			return err
+		}
+	}
+
+	accounts, err := retrieveAccounts(clientCtx, txf, signerAddrs)
+	if err != nil {
+		return err
+	}
+
+	if err := gatherAllSignerInfos(txBuilder, txf.SignMode(), accounts); err != nil {
+		return err
+	}
+
+	if err := signWithMultiSigners(clientCtx, txBuilder, txf.SignMode(), accounts); err != nil {
+		return err
+	}
+
+	txBytes, err := clientCtx.TxConfig.TxEncoder()(txBuilder.GetTx())
+	if err != nil {
+		return err
+	}
+
+	res, err := clientCtx.BroadcastTx(txBytes)
+	if err != nil {
+		return err
+	}
+
+	return clientCtx.PrintProto(res)
+}
+
+type accountInKeyring struct {
+	keyInfo       keyring.Info
+	accountNumber uint64
+	sequence      uint64
+}
+
+func retrieveAccounts(clientCtx client.Context, txf tx.Factory, addrs []sdk.AccAddress) ([]accountInKeyring, error) {
+	var accounts []accountInKeyring
+
+	for _, addr := range addrs {
+		keyInfo, err := clientCtx.Keyring.KeyByAddress(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		// If offline, use accNum and accSeq which were specified in flags
+		accNum := txf.AccountNumber()
+		accSeq := txf.Sequence()
+		if !clientCtx.Offline {
+			accNum, accSeq, err = clientCtx.AccountRetriever.GetAccountNumberSequence(clientCtx, addr)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		accounts = append(accounts, accountInKeyring{
+			keyInfo:       keyInfo,
+			accountNumber: accNum,
+			sequence:      accSeq,
+		})
+	}
+
+	return accounts, nil
+}
+
+func gatherAllSignerInfos(txBuilder client.TxBuilder, signMode signing.SignMode, accounts []accountInKeyring) error {
+	var sigsV2 []signing.SignatureV2
+
+	for _, account := range accounts {
+		sigV2 := signing.SignatureV2{
+			PubKey: account.keyInfo.GetPubKey(),
+			Data: &signing.SingleSignatureData{
+				SignMode:  signMode,
+				Signature: nil,
+			},
+			Sequence: account.sequence,
+		}
+		sigsV2 = append(sigsV2, sigV2)
+	}
+
+	return txBuilder.SetSignatures(sigsV2...)
+}
+
+func signWithMultiSigners(clientCtx client.Context, txBuilder client.TxBuilder, signMode signing.SignMode, accounts []accountInKeyring) error {
+	var sigsV2 []signing.SignatureV2
+
+	for _, account := range accounts {
+		signerData := xauthsigning.SignerData{
+			ChainID:       clientCtx.ChainID,
+			AccountNumber: account.accountNumber,
+			Sequence:      account.sequence,
+		}
+		signBytes, err := clientCtx.TxConfig.SignModeHandler().GetSignBytes(signMode, signerData, txBuilder.GetTx())
+		if err != nil {
+			return err
+		}
+		signature, pubKey, err := clientCtx.Keyring.Sign(account.keyInfo.GetName(), signBytes)
+		if err != nil {
+			return err
+		}
+		sigV2 := signing.SignatureV2{
+			PubKey: pubKey,
+			Data: &signing.SingleSignatureData{
+				SignMode:  signMode,
+				Signature: signature,
+			},
+			Sequence: account.sequence,
+		}
+
+		sigsV2 = append(sigsV2, sigV2)
+	}
+
+	return txBuilder.SetSignatures(sigsV2...)
 }


### PR DESCRIPTION
How to sign with multi-signers is already described in the [Cosmos SDK doc](https://docs.cosmos.network/v0.42/run-node/txs.html#signing-a-transaction-2).
But, Cosmos SDK doesn't provide an all-in-one function for it.

Thus, I implemented it.

I tested it manually using `panacead tx aol add-record ...` for now, since it's not simple to write unit tests due to Keyring and Panacea daemon. But, I'll try to write tests somehow soon.