### PR TITLE
chore: Run docker-publish Github Actions only after the CI is completed

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,10 @@ name: Docker
 # documentation.
 
 on:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
   push:
     branches: [ master ]
     # Publish semver tags as releases.


### PR DESCRIPTION
The `Docker` Github Actions should be started only after the `ci` Actions is completed, because it doesn't make sense to publish a Docker image that doesn't pass the CI.

Reference: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run