### PR TITLE
fix: Return gRPC status code from `grpc_query_*.go` in `x/did` and `x/token`

### DIFF
--- a/x/did/keeper/grpc_query_did.go
+++ b/x/did/keeper/grpc_query_did.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/medibloc/panacea-core/x/did/types"
 	"google.golang.org/grpc/codes"
@@ -21,16 +19,16 @@ func (k Keeper) DID(c context.Context, req *types.QueryDIDRequest) (*types.Query
 
 	didBz, err := base64.StdEncoding.DecodeString(req.DidBase64)
 	if err != nil {
-		return nil, sdkerrors.Wrapf(types.ErrInvalidDID, "DidBase64: %s", req.DidBase64)
+		return nil, status.Error(codes.InvalidArgument, "invalid did_base64")
 	}
 
 	did := string(didBz)
 	docWithSeq := k.GetDIDDocument(ctx, did)
 	if docWithSeq.Empty() {
-		return nil, sdkerrors.Wrapf(types.ErrDIDNotFound, "DID: %s", did)
+		return nil, status.Error(codes.NotFound, "DID not found")
 	}
 	if docWithSeq.Deactivated() {
-		return nil, sdkerrors.Wrapf(types.ErrDIDDeactivated, "DID: %s", did)
+		return nil, status.Error(codes.NotFound, "DID deactivated")
 	}
 
 	return &types.QueryDIDResponse{DidDocumentWithSeq: &docWithSeq}, nil

--- a/x/token/keeper/grpc_query_token.go
+++ b/x/token/keeper/grpc_query_token.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/medibloc/panacea-core/x/token/types"
 	"google.golang.org/grpc/codes"
@@ -49,7 +48,7 @@ func (k Keeper) Token(c context.Context, req *types.QueryTokenRequest) (*types.Q
 	ctx := sdk.UnwrapSDKContext(c)
 
 	if !k.HasToken(ctx, req.Symbol) {
-		return nil, sdkerrors.ErrKeyNotFound
+		return nil, status.Error(codes.NotFound, "token not found")
 	}
 
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.TokenKeyPrefix)


### PR DESCRIPTION
```
                                           ┌──────────────┐
                                           │ HTTP caller  │
                                           └──────────────┘
                                                  ▲
                                                  │
                                                  │
┌─────────────────────────────────────────────────┼──────────────────┐
│                                                 │                  │
│ Cosmos SDK                                      │                  │
│                                                 │                  │
│                                                 │HTTP status code  │
│                                       ┌─────────┴─────────┐        │
│                                       │  gRPC Gateway     │        │
│                                       └───────────────────┘        │
│                                                 ▲                  │
│                                                 │ gRPC error code  │
│                                                 │                  │
│     ┌──────────────────┐              ┌─────────┴─────────┐        │
│     │ msg_server_*.go  │              │  grpc_query_*.go  │        │
│     └────────┬─────────┘              └─────────┬─────────┘        │
│              │                                  │                  │
│              │ ABCI error code                  │ gRPC error code  │
│              ▼                                  ▼                  │
│     ┌──────────────────┐              ┌───────────────────┐        │
│     │ ABCI DeliverTx() │              │ ABCI Query()      │        │
│     └────────┬─────────┘              └───┬───────────────┘        │
│              │                            │ (gRPC-err to ABCI-err internally)
│              │                            │                        │
│              │                            │                        │
│              │ResponseDeliverTx{}         │ ResponseQuery{}        │
│              │                            │                        │
├──────────────┼────────────────────────────┼────────────────────────┤
├──────────────┼────────────────────────────┼────────────────────────┤
│  Tendermint  │                            │                        │
│              ▼                            ▼                        │
│             ┌──────────────────────────────────────┐               │         ┌───────────┐
│             │             ABCI caller              ├───────────────┼────────►│ RPC caller│
│             │                                      │               │         └───────────┘
│             └──────────────────────────────────────┘               │        (Users or other nodes)
│                                                                    │
│                                                                    │
│                                                                    │
└────────────────────────────────────────────────────────────────────┘
```