### PR TITLE
fix: Bump cosmos-sdk to v0.42.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-TBD
+### Bug fixes
+
+- [\#x](https://github.com/medibloc/panacea-core/pull/x) Bump cosmos-sdk to v0.42.9
 
 
 ## [v2.0.1](https://github.com/medibloc/panacea-core/releases/tag/v2.0.1) - 2021-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- [\#x](https://github.com/medibloc/panacea-core/pull/x) Bump cosmos-sdk to v0.42.9
+- [\#213](https://github.com/medibloc/panacea-core/pull/213) Bump cosmos-sdk to v0.42.9
 
 
 ## [v2.0.1](https://github.com/medibloc/panacea-core/releases/tag/v2.0.1) - 2021-07-28

--- a/app/app.go
+++ b/app/app.go
@@ -483,7 +483,7 @@ func New(
 	// CanWithdrawInvariant invariant.
 	// NOTE: staking module is required if HistoricalEntries param > 0
 	app.mm.SetOrderBeginBlockers(
-		upgradetypes.ModuleName, minttypes.ModuleName, distrtypes.ModuleName, slashingtypes.ModuleName,
+		upgradetypes.ModuleName, capabilitytypes.ModuleName, minttypes.ModuleName, distrtypes.ModuleName, slashingtypes.ModuleName,
 		evidencetypes.ModuleName, stakingtypes.ModuleName, ibchost.ModuleName,
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/CosmWasm/wasmd v0.17.0
 	github.com/btcsuite/btcutil v1.0.2
-	github.com/cosmos/cosmos-sdk v0.42.7
+	github.com/cosmos/cosmos-sdk v0.42.9
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cosmos/cosmos-sdk v0.42.5/go.mod h1:3JyT+Ud7QRTO1/ikncNqVhaF526ZKNqh2HGMqXn+QHE=
 github.com/cosmos/cosmos-sdk v0.42.7 h1:f+ZUjao2y93I37RZ7P2d94JdcEsS7Vq64SBLcNITAVc=
 github.com/cosmos/cosmos-sdk v0.42.7/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
+github.com/cosmos/cosmos-sdk v0.42.9 h1:FvF9lkWZz22Xf9K/KEfJvj+g1nFjLpU8GGTt6xkkJPU=
+github.com/cosmos/cosmos-sdk v0.42.9/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=


### PR DESCRIPTION
I'm bumping the cosmos-sdk from v0.42.7 to v0.42.9.

The [v0.42.8](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.8) doesn't have critical fixes, but the [v0.42.9](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.9) contains a [critical bug fix](https://github.com/cosmos/cosmos-sdk/issues/9800) with regard to IBC. Without that, it seems that it's not possible to start IBC channels (I'm not familiar with IBC yet).

The v0.42.9 requires to update an app module manager by adding `x/capability` module to Begin Blockers.
So, I referred to the [cosmos/gaia](https://github.com/cosmos/gaia/commit/1b810239668c98efcc717c1d75be176233e57d02) for that.

TODO: Test whether we can upgrade the `panacead` without hard-forking.



