### PR TITLE
docs: Update URL links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Panacea is a blockchain which is the key infrastructure for our services to rein
 
 - Fast finality powered by [Cosmos SDK](https://cosmos.network/) and [Tendermint](https://tendermint.com/) based on DPoS and PBFT
 - AOL (Append Only Log) for storing various data including medical data footprints
-- DID (Decentralized Identifier) management
+- [DID](https://www.w3.org/TR/did-core/) (Decentralized Identifier) management
 - Smart contracts based on [CosmWasm](https://cosmwasm.com/)
 - [IBC](https://ibcprotocol.org/) (Inter-Blockchain Communication)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Panacea is a blockchain which is the key infrastructure for our services to rein
 - AOL (Append Only Log) for storing various data including medical data footprints
 - DID (Decentralized Identifier) management
 - Smart contracts based on [CosmWasm](https://cosmwasm.com/)
-- IBC (Inter-Blockchain Communication)
+- [IBC](https://ibcprotocol.org/) (Inter-Blockchain Communication)
 
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -24,20 +24,13 @@ Panacea is a blockchain which is the key infrastructure for our services to rein
 
 ### Networks
 
-- [Mainnet](https://github.com/medibloc/panacea-launch)
-- [Testnet](https://github.com/medibloc/panacea-networks)
+- [Mainnet](https://github.com/medibloc/panacea-mainnet)
+- [Testnet](https://github.com/medibloc/panacea-testnet)
 
-### Ecosystem
-
-#### Tools
-
-- [Block Explorers](https://explorer.medibloc.org)
-- [Web Wallet](https://wallet.gopanacea.org)
-
-#### Client SDKs
+### Client SDKs
 
 - [Java SDK](https://github.com/medibloc/panacea-java)
-- [Typescript SDK](https://github.com/medibloc/panacea-js)
+- [Typescript SDK](https://github.com/medibloc/panacea-js) (A [CosmJS](https://github.com/cosmos/cosmjs) wrapper)
 
 
 ## License


### PR DESCRIPTION
I removed URLs of the explorer and the wallet, because the explorer URL has been already posted in each 'network' repo.