### PR TITLE
docs: add a guide to apply the validator's descrption

### DIFF
--- a/.gitbook/guide/join-the-network.md
+++ b/.gitbook/guide/join-the-network.md
@@ -146,7 +146,7 @@ panacead tx staking edit-validator \
   --website "input your website" \
   --identity 6A0D65E29A4CBC8E \
   --details "To infinity and beyond!" \
-  --chain-id panacea-3 \
+  --chain-id <chain_id> \
   --from <key_name>
 ```
 - moniker: Enter the name of the validator.

--- a/.gitbook/guide/join-the-network.md
+++ b/.gitbook/guide/join-the-network.md
@@ -136,3 +136,24 @@ If you want to participate in validating blocks as a validator,
 you can register yourself into the validator set by submitting a transaction.
 
 For more details, see the [CLI guide](interaction-with-the-network-cli.md#staking).
+
+### Edit Validator Description
+
+You can edit your validator's description.
+```bash
+panacead tx staking edit-validator \ 
+  --moniker "choose a moniker" \
+  --website "input your website" \
+  --identity 6A0D65E29A4CBC8E \
+  --details "To infinity and beyond!" \
+  --chain-id panacea-3 \
+  --from <key_name>
+```
+- moniker: Enter the name of the validator.
+- website: Enter the validator's website url.
+- identity: The `identity` can be used as to verify identity with systems like Keybase or UPort. When using with Keybase `identity` should be populated with a 16-digit string that is generated with a [keybase.io](https://keybase.io/) account.
+- details: Enter the validator's details.
+- chain-id: You can enter the mainnet chain ID.
+- from: Enter the name of the key to sign.
+
+If you want to expose the image in Mintscan and Cosmostation's mobile wallet, please refer to [this guide](https://github.com/cosmostation/cosmostation_token_resource).


### PR DESCRIPTION
I have created a document that can modify the validator's description.