### PR TITLE
fix: Modify Dockerfile for Cosmwasm static linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN sha256sum /lib/libwasmvm_muslc.a | grep 0e62296b9f24cf3a05f8513f99cee536c708
 RUN make clean && LEDGER_ENABLED=true BUILD_TAGS=muslc make build
 
 # Final image
-FROM alpine:3.12
+FROM debian:buster-slim
 
 # Copy over binaries from the build-env
 COPY --from=build-env /src/panacea-core/build/panacead /usr/bin/panacead

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.16.5-alpine3.14 AS build-env
 RUN set -eux; apk add --no-cache ca-certificates build-base;
 
 RUN apk add git
-RUN apk add libusb-dev linux-headers
+RUN apk add linux-headers
 
 # Create directory
 RUN mkdir -p /src/panacea-core /src/wasmvm
@@ -16,10 +16,10 @@ COPY . /src/panacea-core
 WORKDIR /src/panacea-core
 
 # Get 'libwasmvm.so' from wasmvm
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v0.16.2/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
-RUN sha256sum /lib/libwasmvm_muslc.a | grep 0e62296b9f24cf3a05f8513f99cee536c7087079855ea6ffb4f89b35eccdaa66
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v0.14.0/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
+RUN sha256sum /lib/libwasmvm_muslc.a | grep 220b85158d1ae72008f099a7ddafe27f6374518816dd5873fd8be272c5418026
 
-RUN make clean && LEDGER_ENABLED=true BUILD_TAGS=muslc make build
+RUN make clean && BUILD_TAGS=muslc make build
 
 # Final image
 FROM debian:buster-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang:1.16.5-buster AS build-env
+FROM golang:1.16.5-alpine3.14 AS build-env
 
 # Install minimum necessary dependencies,
-ENV PACKAGES make git gcc
-RUN apt-get update -y
-RUN apt-get install -y $PACKAGES
+RUN set -eux; apk add --no-cache ca-certificates build-base;
+
+RUN apk add git
+RUN apk add libusb-dev linux-headers
 
 # Create directory
 RUN mkdir -p /src/panacea-core /src/wasmvm
@@ -14,19 +15,17 @@ COPY . /src/panacea-core
 # Set working directory for the 'panacea-core' build
 WORKDIR /src/panacea-core
 
-# Install panacea-core
-RUN make clean && make build
-
 # Get 'libwasmvm.so' from wasmvm
-RUN git clone -b v0.14.0 https://github.com/CosmWasm/wasmvm.git /src/wasmvm
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v0.16.2/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
+RUN sha256sum /lib/libwasmvm_muslc.a | grep 0e62296b9f24cf3a05f8513f99cee536c7087079855ea6ffb4f89b35eccdaa66
+
+RUN make clean && LEDGER_ENABLED=true BUILD_TAGS=muslc make build
 
 # Final image
-FROM debian:buster-slim
+FROM alpine:3.12
 
 # Copy over binaries from the build-env
 COPY --from=build-env /src/panacea-core/build/panacead /usr/bin/panacead
-# Copy 'libwasmvm.so' liberary from the build-env
-COPY --from=build-env /src/wasmvm/api/libwasmvm.so /usr/lib/libwasmvm.so
 
 RUN chmod +x /usr/bin/panacead
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.16.5-alpine3.14 AS build-env
 RUN set -eux; apk add --no-cache ca-certificates build-base;
 
 RUN apk add git
-RUN apk add linux-headers
+RUN apk add libusb-dev linux-headers
 
 # Create directory
 RUN mkdir -p /src/panacea-core /src/wasmvm
@@ -23,10 +23,10 @@ RUN make clean && BUILD_TAGS=muslc make build
 
 # Final image
 FROM debian:buster-slim
-
-# Copy over binaries from the build-env
+#
+## Copy over binaries from the build-env
 COPY --from=build-env /src/panacea-core/build/panacead /usr/bin/panacead
-
+#
 RUN chmod +x /usr/bin/panacead
-
+#
 EXPOSE 26656 26657 1317 9090


### PR DESCRIPTION
Modify Dockerfile for Cosmwasm static linking.

The binary file for panacea `panacead' works well in Linux OS such as ubuntu or alpine.