### PR TITLE
docs: merge split documents for `edit-validator`

### DIFF
--- a/.gitbook/guide/interaction-with-the-network-cli.md
+++ b/.gitbook/guide/interaction-with-the-network-cli.md
@@ -276,6 +276,8 @@ Don't use more `umed` than you have!
 panacead tx staking create-validator \
   --pubkey $(panacead tendermint show-validator) \
   --moniker "choose a moniker" \
+  --details "This is a detail description" \
+  --identity 6A0D65E... \
   --chain-id <chain-id> \
   --commission-rate "0.10" \
   --commission-max-rate "0.20" \
@@ -290,6 +292,8 @@ panacead tx staking create-validator \
   The public key can be resolved by `panacead tendermint show-validator` in the node that you want to make as a validator.
   For details about various key types, please see this [guide](interaction-with-the-network-cli.md#keys).
 - `moniker`: A validator nickname that will be displayed publicly
+- `details`: A detail description of the validator
+- `identity`: The `identity` can be used as to verify identity with systems like Keybase or UPort. When using with Keybase `identity` should be populated with a 16-digit string that is generated with a [keybase.io](https://keybase.io/) account.
 - `commission-rate`: An initial commission rate on block rewards and fees charged to delegators
 - `commission-max-rate`: A maximum commission rate which this validator can charge. This cannot be changed after the
   `create-validator` transaction is processed.
@@ -323,17 +327,22 @@ panacead tx staking edit-validator \
   --moniker "choose a new moniker" \
   --website "https://example.com" \
   --details "This is a detail description" \
+  --identity 6A0D65E... \
   --chain-id <chain_id> \
   --commission-rate "0.15" \
   --from <key_name> \
   --fees "1000000umed"
 ```
 
+For more details of each flag, please see the [`Create your validator`](#create-your-validator) guide.
+
 **Note**: The `--commission-rate` value must adhere to the following invariants:
 
 - Must be between 0 and the validator's `commission-max-rate`
 - Must not exceed the validator's `commission-max-change-rate` which is maximum % point change rate **per day**.
   In other words, a validator can only change its commission once per day and within `commission-max-change-rate` bounds.
+
+If you want to set a logo image of your validator which will be displayed on Mintscan and Cosmostation, please refer to [this guide](https://github.com/cosmostation/cosmostation_token_resource).
 
 ### Delegate to a Validator
 

--- a/.gitbook/guide/join-the-network.md
+++ b/.gitbook/guide/join-the-network.md
@@ -187,25 +187,6 @@ View the status of the network with block explorers.
 If you want to participate in validating blocks as a validator,
 you can register yourself into the validator set by submitting a transaction.
 
-For more details, see the [CLI guide](interaction-with-the-network-cli.md#staking).
+For more details, see the [CLI guide: Create your validator](interaction-with-the-network-cli.md#create-your-validator).
 
-### Edit Validator Description
-
-You can edit your validator's description.
-```bash
-panacead tx staking edit-validator \ 
-  --moniker "choose a moniker" \
-  --website "input your website" \
-  --identity 6A0D65E29A4CBC8E \
-  --details "To infinity and beyond!" \
-  --chain-id <chain_id> \
-  --from <key_name>
-```
-- moniker: Enter the name of the validator.
-- website: Enter the validator's website url.
-- identity: The `identity` can be used as to verify identity with systems like Keybase or UPort. When using with Keybase `identity` should be populated with a 16-digit string that is generated with a [keybase.io](https://keybase.io/) account.
-- details: Enter the validator's details.
-- chain-id: You can enter the mainnet chain ID.
-- from: Enter the name of the key to sign.
-
-If you want to expose the image in Mintscan and Cosmostation's mobile wallet, please refer to [this guide](https://github.com/cosmostation/cosmostation_token_resource).
+If you already joined as a validator and if you want to modify your validator details, please see the [CLI guide: Edit validator description](interaction-with-the-network-cli.md#edit-validator-description).


### PR DESCRIPTION
Although we already added a `edit-validator` guide to the `join-the-network.md` (PR https://github.com/medibloc/panacea-core/pull/248), I just found that the `interaction-with-the-network-cli.md` has already had the `edit-validator` guide.

To avoid splitting information, I merged all `edit-validator` guides into the `interaction-with-the-network-cli.md` . Instead, I put only links in the `join-the-network.md`.