### PR TITLE
feat: Apply Signature Verification for SellData and Build Tx Command-Line

### DIFF
--- a/x/market/client/cli/parse.go
+++ b/x/market/client/cli/parse.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	FlagDealFile = "deal-file"
+	FlagDealFile    = "deal-file"
+	ReceiptDataFile = "receipt-file"
 )
 
 type createDealInputs struct {
@@ -14,6 +15,24 @@ type createDealInputs struct {
 	Budget                string   `json:"budget"`
 	MaxNumData            uint64   `json:"max_num_data"`
 	TrustedDataValidators []string `json:"trusted_data_validators"`
+}
+
+type sellDataInputs struct {
+	Cert   DataValidationCertification `json:"certificate"`
+	Seller string                      `json:"seller"`
+}
+
+type DataValidationCertification struct {
+	UnsignedCert UnsignedDataValidationCertification `json:"unsigned_cert"`
+	Signature    string                              `json:"signature"`
+}
+
+type UnsignedDataValidationCertification struct {
+	DealId               uint64 `json:"deal_id"`
+	DataHash             string `json:"data_hash"`
+	EncryptedDataUrl     string `json:"encrypted_data_url"`
+	DataValidatorAddress string `json:"data_validator_address"`
+	RequesterAddress     string `json:"requester_address"`
 }
 
 type XCreateDealInputs createDealInputs
@@ -28,5 +47,20 @@ func (input *createDealInputs) UnmarshalJSON(data []byte) error {
 	}
 
 	*input = createDealInputs(createDeal)
+	return nil
+}
+
+type XSellDataInputs sellDataInputs
+
+func (input *sellDataInputs) UnmarshalJSON(data []byte) error {
+	var sellData XSellDataInputs
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	if err := dec.Decode(&sellData); err != nil {
+		return err
+	}
+
+	*input = sellDataInputs(sellData)
 	return nil
 }

--- a/x/market/client/cli/tx.go
+++ b/x/market/client/cli/tx.go
@@ -18,5 +18,6 @@ func GetTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewCreateDealCmd())
+	cmd.AddCommand(SellDataCmd())
 	return cmd
 }

--- a/x/market/client/cli/txDeal.go
+++ b/x/market/client/cli/txDeal.go
@@ -40,6 +40,33 @@ func NewCreateDealCmd() *cobra.Command {
 	return cmd
 }
 
+func SellDataCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sell-data [flags]",
+		Short: "sell data",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return nil
+			}
+
+			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
+
+			txf, msg, err := NewSellDataMsg(clientCtx, txf, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
+		},
+	}
+
+	cmd.Flags().String(ReceiptDataFile, "", "Receipt data file path")
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
 func NewBuildCreateDealMsg(clientCtx client.Context, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
 	deal, err := parseCreateDealFlags(fs)
 	if err != nil {
@@ -81,4 +108,49 @@ func parseCreateDealFlags(fs *flag.FlagSet) (*createDealInputs, error) {
 	}
 
 	return deal, nil
+}
+
+func NewSellDataMsg(clientCtx client.Context, txf tx.Factory, fs *flag.FlagSet) (tx.Factory, sdk.Msg, error) {
+	sellData, err := parseSellDataFlags(fs)
+	if err != nil {
+		return txf, nil, fmt.Errorf("failed to parse receipt: %w", err)
+	}
+
+	unSigned := types.UnsignedDataValidationCertificate{
+		DealId:               sellData.Cert.UnsignedCert.DealId,
+		DataHash:             sellData.Cert.UnsignedCert.DataHash,
+		EncryptedDataUrl:     sellData.Cert.UnsignedCert.EncryptedDataUrl,
+		DataValidatorAddress: sellData.Cert.UnsignedCert.DataValidatorAddress,
+		RequesterAddress:     sellData.Cert.UnsignedCert.RequesterAddress,
+	}
+
+	signed := types.DataValidationCertificate{
+		UnsignedCert: &unSigned,
+		Signature:    []byte(sellData.Cert.Signature),
+	}
+
+	msg := types.NewMsgSellData(signed, clientCtx.GetFromAddress().String())
+
+	return txf, msg, nil
+}
+
+func parseSellDataFlags(fs *flag.FlagSet) (*sellDataInputs, error) {
+	sellData := &sellDataInputs{}
+	receiptFile, _ := fs.GetString(ReceiptDataFile)
+
+	if receiptFile == "" {
+		return nil, fmt.Errorf("need receipt json file using --%s flag", ReceiptDataFile)
+	}
+
+	contents, err := ioutil.ReadFile(receiptFile)
+	if err != nil {
+		return nil, err
+	}
+
+	err = sellData.UnmarshalJSON(contents)
+	if err != nil {
+		return nil, err
+	}
+
+	return sellData, nil
 }

--- a/x/market/client/cli/txDeal_test.go
+++ b/x/market/client/cli/txDeal_test.go
@@ -24,13 +24,3 @@ func (suite *txTestSuite) TestNewMsgCreateDeal() {
 func (suite *txTestSuite) TestNewMsgSellData() {
 
 }
-
-// TODO: Test Client Command-Line MsgSellData
-func (suite *txTestSuite) TestNewMsgSellData() {
-
-}
-
-// TODO: Test Client Command-Line MsgSellData
-func (suite *txTestSuite) TestNewMsgSellData() {
-
-}

--- a/x/market/client/cli/txDeal_test.go
+++ b/x/market/client/cli/txDeal_test.go
@@ -19,3 +19,18 @@ func TestTxTestSuite(t *testing.T) {
 func (suite *txTestSuite) TestNewMsgCreateDeal() {
 
 }
+
+// TODO: Test Client Command-Line MsgSellData
+func (suite *txTestSuite) TestNewMsgSellData() {
+
+}
+
+// TODO: Test Client Command-Line MsgSellData
+func (suite *txTestSuite) TestNewMsgSellData() {
+
+}
+
+// TODO: Test Client Command-Line MsgSellData
+func (suite *txTestSuite) TestNewMsgSellData() {
+
+}

--- a/x/market/keeper/deal_test.go
+++ b/x/market/keeper/deal_test.go
@@ -29,6 +29,8 @@ var (
 	acc3                   = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
 	defaultFunds sdk.Coins = sdk.NewCoins(sdk.NewCoin("umed", sdk.NewInt(10000000000)))
 	zeroFunds    sdk.Coins = sdk.NewCoins(sdk.NewCoin("umed", sdk.NewInt(0)))
+	privKey                = secp256k1.GenPrivKey()
+	newAddr                = sdk.AccAddress(privKey.PubKey().Address())
 )
 
 func (suite *dealTestSuite) BeforeTest(_, _ string) {
@@ -117,7 +119,7 @@ func (suite *dealTestSuite) TestSellOwnData() {
 		DataSchema:            []string{acc1.String()},
 		Budget:                &sdk.Coin{Denom: "umed", Amount: sdk.NewInt(10000000)},
 		MaxNumData:            10000,
-		TrustedDataValidators: []string{acc2.String()},
+		TrustedDataValidators: []string{newAddr.String()},
 		Owner:                 acc1.String(),
 	}
 
@@ -130,10 +132,22 @@ func (suite *dealTestSuite) TestSellOwnData() {
 	reward, err := suite.MarketKeeper.SellOwnData(suite.Ctx, acc3, cert)
 	suite.Require().NoError(err)
 
-	suite.Require().Equal(cert.GetUnsignedCert().GetDealId(), deal.GetDealId())
+	suite.Require().Equal(cert.UnsignedCert.GetDealId(), deal.GetDealId())
 	sellerBalance := suite.BankKeeper.GetBalance(suite.Ctx, acc3, "umed")
 	suite.Require().Equal(sellerBalance, reward)
 }
+
+//func (suite *dealTestSuite) TestVerify() {
+//	cert := makeTestCert()
+//
+//	validatorAddr, err := sdk.AccAddressFromBech32(cert.UnsignedCert.GetDataValidatorAddress())
+//	suite.Require().NoError(err)
+//	suite.Require().Equal(newAddr, validatorAddr)
+//
+//	verify, err := suite.MarketKeeper.Verify(suite.Ctx, validatorAddr, *cert.UnsignedCert, cert)
+//	suite.Require().Equal(true, verify)
+//	suite.Require().NoError(err)
+//}
 
 func makeTestDeal() types.Deal {
 	return types.Deal{
@@ -154,13 +168,23 @@ func makeTestCert() types.DataValidationCertificate {
 		DealId:               2,
 		DataHash:             "1a312c123x23",
 		EncryptedDataUrl:     "https://panacea.org/a/123.json",
-		DataValidatorAddress: acc2.String(),
+		DataValidatorAddress: newAddr.String(),
 		RequesterAddress:     acc3.String(),
+	}
+
+	marshal, err := uCert.Marshal()
+	if err != nil {
+		return types.DataValidationCertificate{}
+	}
+
+	sign, err := privKey.Sign(marshal)
+	if err != nil {
+		return types.DataValidationCertificate{}
 	}
 
 	return types.DataValidationCertificate{
 		UnsignedCert: &uCert,
-		Signature:    acc1.Bytes(),
+		Signature:    sign,
 	}
 
 }

--- a/x/market/keeper/msg_server_deal.go
+++ b/x/market/keeper/msg_server_deal.go
@@ -50,7 +50,15 @@ func (m msgServer) SellData(goCtx context.Context, msg *types.MsgSellData) (*typ
 		Signature:    msg.Cert.Signature,
 	}
 
-	//TODO: Verification function for original data and signature refer to auth.go
+	validatorAddr, err := sdk.AccAddressFromBech32(unSignedCert.GetDataValidatorAddress())
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = m.Keeper.Verify(ctx, validatorAddr, unSignedCert, cert)
+	if err != nil {
+		return nil, err
+	}
 
 	reward, err := m.Keeper.SellOwnData(ctx, seller, cert)
 	if err != nil {
@@ -59,3 +67,4 @@ func (m msgServer) SellData(goCtx context.Context, msg *types.MsgSellData) (*typ
 
 	return &types.MsgSellDataResponse{Reward: &reward}, nil
 }
+

--- a/x/market/types/codec.go
+++ b/x/market/types/codec.go
@@ -10,12 +10,14 @@ import (
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgCreateDeal{}, "did/CreateDeal", nil)
+	cdc.RegisterConcrete(&MsgCreateDeal{}, "market/CreateDeal", nil)
+	cdc.RegisterConcrete(&MsgSellData{}, "market/SellData", nil)
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgCreateDeal{},
+		&MsgSellData{},
 	)
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/x/market/types/errors.go
+++ b/x/market/types/errors.go
@@ -10,4 +10,5 @@ import (
 var (
 	ErrDealAlreadyExist = sdkerrors.Register(ModuleName, 1, "deal already exist")
 	ErrNotEnoughBalance = sdkerrors.Register(ModuleName, 2, "The owner's balance is not enough to make deal")
+	ErrInvalidSignature = sdkerrors.Register(ModuleName, 3, "invalid data validator signature")
 )

--- a/x/market/types/message_deal.go
+++ b/x/market/types/message_deal.go
@@ -74,7 +74,7 @@ func (msg *MsgCreateDeal) GetSigners() []sdk.AccAddress {
 
 var _ sdk.Msg = &MsgSellData{}
 
-func NewSellData(cert DataValidationCertificate, seller string) *MsgSellData {
+func NewMsgSellData(cert DataValidationCertificate, seller string) *MsgSellData {
 	return &MsgSellData{
 		Cert:   &cert,
 		Seller: seller,


### PR DESCRIPTION
What I done
- Build Tx Command-Line for ```SellData```.
- Apply Verification for DataValidator Signature for ```SellData```.
- Register ```MsgSellData``` in ```types/codec.go```.

TODO
- Replace ```max_num_data``` field and ```cur_num_data``` field with pricePerData.