### PR TITLE
feat: Command Line for Register Data Validator

### DIFF
--- a/x/datapool/client/cli/tx.go
+++ b/x/datapool/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -19,7 +20,6 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	// this line is used by starport scaffolding # 1
-
+	cmd.AddCommand(CmdRegisterDataValidator())
 	return cmd
 }

--- a/x/datapool/client/cli/txPool.go
+++ b/x/datapool/client/cli/txPool.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/medibloc/panacea-core/v2/x/datapool/types"
+	"github.com/spf13/cobra"
+)
+
+func CmdRegisterDataValidator() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "register-data-validator [endpoint URL]",
+		Short: "register data validator",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			fromDataValidatorAddress := clientCtx.GetFromAddress()
+			dataValidator := types.DataValidator{
+				Address:  fromDataValidatorAddress.String(),
+				Endpoint: args[0],
+			}
+			msg := types.NewMsgRegisterDataValidator(&dataValidator)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}

--- a/x/datapool/types/message_pool.go
+++ b/x/datapool/types/message_pool.go
@@ -24,7 +24,11 @@ func (msg *MsgRegisterDataValidator) Type() string {
 func (msg *MsgRegisterDataValidator) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.ValidatorDetail.Address)
 	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid data validator address (%s)", err)
+	}
+
+	if msg.ValidatorDetail.Endpoint == "" {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "empty data validator endpoint URL")
 	}
 	return nil
 }
@@ -55,7 +59,7 @@ func (msg *MsgCreatePool) Type() string {
 func (msg *MsgCreatePool) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Curator)
 	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid curator address (%s)", err)
 	}
 	return nil
 }
@@ -86,7 +90,7 @@ func (msg *MsgSellData) Type() string {
 func (msg *MsgSellData) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Seller)
 	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid seller address (%s)", err)
 	}
 	return nil
 }
@@ -117,7 +121,7 @@ func (msg *MsgBuyDataAccessNFT) Type() string {
 func (msg *MsgBuyDataAccessNFT) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Buyer)
 	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid buyer address (%s)", err)
 	}
 	return nil
 }
@@ -148,7 +152,7 @@ func (msg *MsgRedeemDataAccessNFT) Type() string {
 func (msg *MsgRedeemDataAccessNFT) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Redeemer)
 	if err != nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid redeemer address (%s)", err)
 	}
 	return nil
 }


### PR DESCRIPTION
- Command-Line Interface(CLI) for Register Data Validator.
- Add `CmdRegisterDataValidator` and modify `ValidateBasic` function.