### PR TITLE
ci: upgrade golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: 1.17
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       run: make test
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         version: v1.30
 


### PR DESCRIPTION
All the github actions fail in golangci-lint step with error of `error: buildir: failed to load package goarch: could not load export data`. I found the [same issue](https://github.com/golangci/golangci-lint-action/issues/434) we've encountered. They said they removed the installation of go step at all, so do upgrade to v3.