### PR TITLE
fix: datapool genesis validate condition bug

### DIFF
--- a/x/datapool/types/genesis.go
+++ b/x/datapool/types/genesis.go
@@ -22,8 +22,10 @@ func (gs GenesisState) Validate() error {
 		return err
 	}
 
-	if err := sdk.VerifyAddressFormat(gs.NftContractAddress); err != nil {
-		return err
+	if gs.NftContractAddress != nil {
+		if err := sdk.VerifyAddressFormat(gs.NftContractAddress); err != nil {
+			return err
+		}
 	}
 	// this line is used by starport scaffolding # ibc/genesistype/validate
 


### PR DESCRIPTION
If genesis state doesn't have NFT contract address, the validation of genesis state fails. So, check first whether genesis state has NFT contract address. 