### PR TITLE
feat: added ability mint shareToken

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -202,7 +202,7 @@ var (
 		govtypes.ModuleName:            {authtypes.Burner},
 		ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
 		wasm.ModuleName:                {authtypes.Burner},
-		datapooltypes.ModuleName:       nil,
+		datapooltypes.ModuleName:       {authtypes.Minter},
 	}
 )
 

--- a/types/testsuite/suite.go
+++ b/types/testsuite/suite.go
@@ -119,7 +119,7 @@ func (suite *TestSuite) SetupTest() {
 		govtypes.ModuleName:            {authtypes.Burner},
 		ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
 		wasm.ModuleName:                {authtypes.Burner},
-		datapooltypes.ModuleName:       nil,
+		datapooltypes.ModuleName:       {authtypes.Minter},
 	}
 
 	modAccAddrs := make(map[string]bool)

--- a/x/datapool/keeper/pool.go
+++ b/x/datapool/keeper/pool.go
@@ -376,22 +376,6 @@ func (k Keeper) SellData(ctx sdk.Context, seller sdk.AccAddress, cert types.Data
 	return shareToken, nil
 }
 
-func (k Keeper) mintPoolShareToAccount(ctx sdk.Context, poolID, amount uint64, addr sdk.AccAddress) (*sdk.Coin, error) {
-	shareToken := types.GetAccumPoolShareToken(poolID, amount)
-
-	shareTokens := sdk.Coins{shareToken}
-	err := k.bankKeeper.MintCoins(ctx, types.ModuleName, shareTokens)
-	if err != nil {
-		return nil, sdkerrors.Wrap(types.ErrFailedMintShareToken, err.Error())
-	}
-
-	err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, addr, shareTokens)
-	if err != nil {
-		return nil, sdkerrors.Wrap(types.ErrFailedMintShareToken, err.Error())
-	}
-	return &shareToken, nil
-}
-
 // verifySignature verifies that the signature of the dataValidator is correct
 func (k Keeper) verifySignature(ctx sdk.Context, dataValidatorCert types.DataValidationCertificate) error {
 	dataValidator := dataValidatorCert.UnsignedCert.DataValidator
@@ -464,6 +448,22 @@ func (k Keeper) increaseCurNumAndUpdatePool(ctx sdk.Context, pool *types.Pool) {
 	}
 
 	k.SetPool(ctx, pool)
+}
+
+func (k Keeper) mintPoolShareToAccount(ctx sdk.Context, poolID, amount uint64, addr sdk.AccAddress) (*sdk.Coin, error) {
+	shareToken := types.GetAccumPoolShareToken(poolID, amount)
+
+	shareTokens := sdk.Coins{shareToken}
+	err := k.bankKeeper.MintCoins(ctx, types.ModuleName, shareTokens)
+	if err != nil {
+		return nil, sdkerrors.Wrap(types.ErrFailedMintShareToken, err.Error())
+	}
+
+	err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, addr, shareTokens)
+	if err != nil {
+		return nil, sdkerrors.Wrap(types.ErrFailedMintShareToken, err.Error())
+	}
+	return &shareToken, nil
 }
 
 func contains(validators []string, validator string) bool {

--- a/x/datapool/keeper/pool.go
+++ b/x/datapool/keeper/pool.go
@@ -211,6 +211,7 @@ func (k Keeper) CreatePool(ctx sdk.Context, curator sdk.AccAddress, poolParams t
 	k.SetPool(ctx, newPool)
 
 	// mint tokens as many as targetNumData
+	k.setInitialSupply(ctx, poolID)
 	err = k.mintPoolShareToken(ctx, poolID, poolParams.TargetNumData)
 	if err != nil {
 		return 0, sdkerrors.Wrapf(err, "failed to mint share token")
@@ -455,8 +456,6 @@ func (k Keeper) increaseCurNumAndUpdatePool(ctx sdk.Context, pool *types.Pool) {
 }
 
 func (k Keeper) mintPoolShareToken(ctx sdk.Context, poolID, amount uint64) error {
-	k.setInitialSupply(ctx, poolID)
-
 	shareToken := types.GetAccumPoolShareToken(poolID, amount)
 	shareTokens := sdk.NewCoins(shareToken)
 	err := k.bankKeeper.MintCoins(ctx, types.ModuleName, shareTokens)

--- a/x/datapool/keeper/pool.go
+++ b/x/datapool/keeper/pool.go
@@ -216,6 +216,7 @@ func (k Keeper) CreatePool(ctx sdk.Context, curator sdk.AccAddress, poolParams t
 	return newPool.GetPoolId(), nil
 }
 
+// setInitialSupply defines supply to be initialized for tokens to be minted.
 func (k Keeper) setInitialSupply(ctx sdk.Context, poolID uint64) {
 	supply := banktypes.Supply{
 		Total: sdk.NewCoins(types.GetAccumPoolShareToken(poolID, 0)),

--- a/x/datapool/keeper/pool_test.go
+++ b/x/datapool/keeper/pool_test.go
@@ -353,9 +353,16 @@ func (suite *poolTestSuite) TestSellData() {
 	suite.Equal(uint64(1), getPool.CurNumData)
 	suite.Equal(types.PENDING, getPool.Status)
 
+	// Check actually send to seller
 	requesterShareToken := suite.BankKeeper.GetBalance(suite.Ctx, requesterAddr, "DP/1")
 	suite.Require().Equal("DP/1", requesterShareToken.Denom)
 	suite.Require().Equal(sdk.NewInt(1), requesterShareToken.Amount)
+
+	// Check supply
+	supply := suite.BankKeeper.GetSupply(suite.Ctx)
+	suite.Require().Equal(1, len(supply.GetTotal()))
+	suite.Require().Equal("DP/1", supply.GetTotal()[0].Denom)
+	suite.Require().Equal(sdk.NewInt(1), supply.GetTotal()[0].Amount)
 }
 
 func (suite *poolTestSuite) TestSellData_change_status_activity() {
@@ -387,9 +394,16 @@ func (suite *poolTestSuite) TestSellData_change_status_activity() {
 	suite.Equal(uint64(1), getPool.CurNumData)
 	suite.Equal(types.ACTIVE, getPool.Status)
 
+	// Check actually send to seller
 	requesterShareToken := suite.BankKeeper.GetBalance(suite.Ctx, requesterAddr, "DP/1")
 	suite.Require().Equal("DP/1", requesterShareToken.Denom)
 	suite.Require().Equal(sdk.NewInt(1), requesterShareToken.Amount)
+
+	// Check supply
+	supply := suite.BankKeeper.GetSupply(suite.Ctx)
+	suite.Require().Equal(1, len(supply.GetTotal()))
+	suite.Require().Equal("DP/1", supply.GetTotal()[0].Denom)
+	suite.Require().Equal(sdk.NewInt(1), supply.GetTotal()[0].Amount)
 }
 
 func (suite *poolTestSuite) TestSellData_not_same_seller() {

--- a/x/datapool/keeper/pool_test.go
+++ b/x/datapool/keeper/pool_test.go
@@ -329,14 +329,15 @@ func (suite *poolTestSuite) TestSetDataCertificate() {
 }
 
 func (suite *poolTestSuite) TestSellData() {
-	poolID := uint64(1)
-	round := uint64(1)
-	dataHash := []byte("dataHash")
-
 	suite.setDataValidatorAccount()
 
-	pool := makeTestDataPool(poolID)
-	suite.DataPoolKeeper.SetPool(suite.Ctx, pool)
+	suite.TestCreatePool()
+
+	pool, err := suite.DataPoolKeeper.GetPool(suite.Ctx, 1)
+	suite.Require().NoError(err)
+	poolID := pool.PoolId
+	round := pool.Round
+	dataHash := []byte("dataHash")
 
 	cert, err := makeTestDataCertificate(suite.Cdc.Marshaler, poolID, round, dataHash)
 	suite.Require().NoError(err)
@@ -351,16 +352,23 @@ func (suite *poolTestSuite) TestSellData() {
 	suite.Require().NoError(err)
 	suite.Equal(uint64(1), getPool.CurNumData)
 	suite.Equal(types.PENDING, getPool.Status)
+
+	requesterShareToken := suite.BankKeeper.GetBalance(suite.Ctx, requesterAddr, "DP/1")
+	suite.Require().Equal("DP/1", requesterShareToken.Denom)
+	suite.Require().Equal(sdk.NewInt(1), requesterShareToken.Amount)
 }
 
 func (suite *poolTestSuite) TestSellData_change_status_activity() {
-	poolID := uint64(1)
-	round := uint64(1)
-	dataHash := []byte("dataHash")
-
 	suite.setDataValidatorAccount()
 
-	pool := makeTestDataPool(poolID)
+	suite.TestCreatePool()
+
+	pool, err := suite.DataPoolKeeper.GetPool(suite.Ctx, 1)
+	suite.Require().NoError(err)
+	poolID := pool.PoolId
+	round := pool.Round
+	dataHash := []byte("dataHash")
+
 	// Modify the target data of the pool
 	pool.PoolParams.TargetNumData = 1
 	suite.DataPoolKeeper.SetPool(suite.Ctx, pool)
@@ -378,6 +386,10 @@ func (suite *poolTestSuite) TestSellData_change_status_activity() {
 	suite.Require().NoError(err)
 	suite.Equal(uint64(1), getPool.CurNumData)
 	suite.Equal(types.ACTIVE, getPool.Status)
+
+	requesterShareToken := suite.BankKeeper.GetBalance(suite.Ctx, requesterAddr, "DP/1")
+	suite.Require().Equal("DP/1", requesterShareToken.Denom)
+	suite.Require().Equal(sdk.NewInt(1), requesterShareToken.Amount)
 }
 
 func (suite *poolTestSuite) TestSellData_not_same_seller() {
@@ -445,14 +457,15 @@ func (suite *poolTestSuite) TestSellData_invalid_signature() {
 }
 
 func (suite *poolTestSuite) TestSellData_duplicate_data() {
-	poolID := uint64(1)
-	round := uint64(1)
-	dataHash := []byte("dataHash")
-
 	suite.setDataValidatorAccount()
 
-	pool := makeTestDataPool(poolID)
-	suite.DataPoolKeeper.SetPool(suite.Ctx, pool)
+	suite.TestCreatePool()
+
+	pool, err := suite.DataPoolKeeper.GetPool(suite.Ctx, 1)
+	suite.Require().NoError(err)
+	poolID := pool.PoolId
+	round := pool.Round
+	dataHash := []byte("dataHash")
 
 	cert, err := makeTestDataCertificate(suite.Cdc.Marshaler, poolID, round, dataHash)
 	suite.Require().NoError(err)

--- a/x/datapool/keeper/pool_test.go
+++ b/x/datapool/keeper/pool_test.go
@@ -362,7 +362,7 @@ func (suite *poolTestSuite) TestSellData() {
 	supply := suite.BankKeeper.GetSupply(suite.Ctx)
 	suite.Require().Equal(1, len(supply.GetTotal()))
 	suite.Require().Equal("DP/1", supply.GetTotal()[0].Denom)
-	suite.Require().Equal(sdk.NewInt(1), supply.GetTotal()[0].Amount)
+	suite.Require().Equal(sdk.NewInt(100), supply.GetTotal()[0].Amount)
 }
 
 func (suite *poolTestSuite) TestSellData_change_status_activity() {
@@ -403,7 +403,7 @@ func (suite *poolTestSuite) TestSellData_change_status_activity() {
 	supply := suite.BankKeeper.GetSupply(suite.Ctx)
 	suite.Require().Equal(1, len(supply.GetTotal()))
 	suite.Require().Equal("DP/1", supply.GetTotal()[0].Denom)
-	suite.Require().Equal(sdk.NewInt(1), supply.GetTotal()[0].Amount)
+	suite.Require().Equal(sdk.NewInt(100), supply.GetTotal()[0].Amount)
 }
 
 func (suite *poolTestSuite) TestSellData_not_same_seller() {

--- a/x/datapool/types/errors.go
+++ b/x/datapool/types/errors.go
@@ -17,4 +17,5 @@ var (
 	ErrInvalidDataValidationCert  = sdkerrors.Register(ModuleName, 9, "certificate is not valid")
 	ErrExistSameDataHash          = sdkerrors.Register(ModuleName, 10, "data already exists in the pool")
 	ErrGetDataValidationCert      = sdkerrors.Register(ModuleName, 11, "failed get certificate.")
+	ErrFailedMintShareToken       = sdkerrors.Register(ModuleName, 12, "failed mint share token.")
 )

--- a/x/datapool/types/expected_keepers.go
+++ b/x/datapool/types/expected_keepers.go
@@ -4,11 +4,19 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/bank/exported"
 )
 
 type BankKeeper interface {
 	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+
+	MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
+	BurnCoins(ctx sdk.Context, name string, amt sdk.Coins) error
+
+	GetSupply(ctx sdk.Context) exported.SupplyI
+	SetSupply(ctx sdk.Context, supply exported.SupplyI)
 }
 
 type AccountKeeper interface {


### PR DESCRIPTION
This function uses `BankKeeper` directly without using the `x/token` module.
Because I know that `x/module` is deprecated.

When data is sold, `shareToken` is minted and sent to the seller.