### PR TITLE
feat: add query params of datapool module

### DIFF
--- a/proto/panacea/datapool/v2/query.proto
+++ b/proto/panacea/datapool/v2/query.proto
@@ -5,6 +5,7 @@ option go_package = "github.com/medibloc/panacea-core/x/datapool/types";
 
 import "google/api/annotations.proto";
 import "panacea/datapool/v2/pool.proto";
+import "panacea/datapool/v2/genesis.proto";
 
 // Query defines the gRPC querier service.
 service Query {
@@ -16,6 +17,11 @@ service Query {
   // DataValidator returns a DataValidator.
   rpc DataValidator(QueryDataValidatorRequest) returns (QueryDataValidatorResponse) {
     option (google.api.http).get = "/panacea/datapool/v2/data_validator";
+  }
+
+  // DataPoolParams returns params of x/datapool module
+  rpc DataPoolParams(QueryDataPoolParamsRequest) returns (QueryDataPoolParamsResponse) {
+    option (google.api.http).get = "/panacea/datapool/v2/params";
   }
 }
 
@@ -37,4 +43,12 @@ message QueryDataValidatorRequest {
 // QueryDataValidatorResponse is the response type for the Query/DataValidator RPC method.
 message QueryDataValidatorResponse {
   DataValidator data_validator = 1;
+}
+
+// QueryDataPoolParamsRequest is the request type for the Query/DataPoolParamsRequest RPC method.
+message QueryDataPoolParamsRequest {}
+
+// QueryDataPoolParamsResponse is the response type for the Query/DataPoolParamsResponse RPC method.
+message QueryDataPoolParamsResponse {
+  Params params = 1;
 }

--- a/x/datapool/README.md
+++ b/x/datapool/README.md
@@ -92,7 +92,7 @@ panacead tx datapool create-pool create_pool_sample.json --from $CURATOR $TX_FLA
 
 ### Query curator NFT
 ```shell
-CONTRACT="panacea14hj2tavq8fpesdwxxcu44rty3hh90vhu4mda6e"
+CONTRACT=$(panacead q datapool params -o json | jq -r '.data_pool_nft_contract_address')
 QUERY_TOKEN_INFO=$(jq -n --arg owner $CURATOR '{"tokens":{"owner":$owner}}')
 panacead q wasm contract-state smart $CONTRACT $QUERY_TOKEN_INFO -o json
 ```

--- a/x/datapool/client/cli/query.go
+++ b/x/datapool/client/cli/query.go
@@ -28,5 +28,6 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 
 	cmd.AddCommand(CmdGetDataValidator())
 	cmd.AddCommand(CmdGetPool())
+	cmd.AddCommand(CmdGetParams())
 	return cmd
 }

--- a/x/datapool/client/cli/queryParams.go
+++ b/x/datapool/client/cli/queryParams.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/medibloc/panacea-core/v2/x/datapool/types"
+	"github.com/spf13/cobra"
+)
+
+func CmdGetParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "Query params of datapool module",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			res, err := queryClient.DataPoolParams(cmd.Context(), &types.QueryDataPoolParamsRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/datapool/keeper/grpc_query_pool.go
+++ b/x/datapool/keeper/grpc_query_pool.go
@@ -46,3 +46,15 @@ func (k Keeper) DataValidator(goCtx context.Context, req *types.QueryDataValidat
 
 	return &types.QueryDataValidatorResponse{DataValidator: &dataValidator}, nil
 }
+
+func (k Keeper) DataPoolParams(goCtx context.Context, req *types.QueryDataPoolParamsRequest) (*types.QueryDataPoolParamsResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	params := k.GetParams(ctx)
+
+	return &types.QueryDataPoolParamsResponse{Params: &params}, nil
+}

--- a/x/datapool/keeper/grpc_query_pool_test.go
+++ b/x/datapool/keeper/grpc_query_pool_test.go
@@ -21,6 +21,25 @@ func TestQueryPoolTest(t *testing.T) {
 	suite.Run(t, new(queryPoolTestSuite))
 }
 
+var (
+	nftContractAddr = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+)
+
+func (suite queryPoolTestSuite) TestQueryDataPoolParams() {
+	// set datapool module params
+	params := &types.Params{
+		DataPoolNftContractAddress: nftContractAddr.String(),
+		DataPoolCodeId:             2,
+		DataPoolDeposit:            sdk.NewCoin(assets.MicroMedDenom, sdk.NewInt(10000)),
+	}
+
+	suite.DataPoolKeeper.SetParams(suite.Ctx, *params)
+
+	res, err := suite.DataPoolKeeper.DataPoolParams(sdk.WrapSDKContext(suite.Ctx), &types.QueryDataPoolParamsRequest{})
+	suite.Require().NoError(err)
+	suite.Require().Equal(params, res.GetParams())
+}
+
 func (suite *queryPoolTestSuite) TestQueryDataValidator() {
 	dataValidator := types.DataValidator{
 		Address:  dataVal1.String(),

--- a/x/datapool/types/query.pb.go
+++ b/x/datapool/types/query.pb.go
@@ -208,41 +208,130 @@ func (m *QueryDataValidatorResponse) GetDataValidator() *DataValidator {
 	return nil
 }
 
+// QueryDataPoolParamsRequest is the request type for the Query/DataPoolParamsRequest RPC method.
+type QueryDataPoolParamsRequest struct {
+}
+
+func (m *QueryDataPoolParamsRequest) Reset()         { *m = QueryDataPoolParamsRequest{} }
+func (m *QueryDataPoolParamsRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryDataPoolParamsRequest) ProtoMessage()    {}
+func (*QueryDataPoolParamsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_f3fda93d2b4f4508, []int{4}
+}
+func (m *QueryDataPoolParamsRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryDataPoolParamsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryDataPoolParamsRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryDataPoolParamsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryDataPoolParamsRequest.Merge(m, src)
+}
+func (m *QueryDataPoolParamsRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryDataPoolParamsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryDataPoolParamsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryDataPoolParamsRequest proto.InternalMessageInfo
+
+// QueryDataPoolParamsResponse is the response type for the Query/DataPoolParamsResponse RPC method.
+type QueryDataPoolParamsResponse struct {
+	Params *Params `protobuf:"bytes,1,opt,name=params,proto3" json:"params,omitempty"`
+}
+
+func (m *QueryDataPoolParamsResponse) Reset()         { *m = QueryDataPoolParamsResponse{} }
+func (m *QueryDataPoolParamsResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryDataPoolParamsResponse) ProtoMessage()    {}
+func (*QueryDataPoolParamsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_f3fda93d2b4f4508, []int{5}
+}
+func (m *QueryDataPoolParamsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryDataPoolParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryDataPoolParamsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryDataPoolParamsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryDataPoolParamsResponse.Merge(m, src)
+}
+func (m *QueryDataPoolParamsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryDataPoolParamsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryDataPoolParamsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryDataPoolParamsResponse proto.InternalMessageInfo
+
+func (m *QueryDataPoolParamsResponse) GetParams() *Params {
+	if m != nil {
+		return m.Params
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*QueryPoolRequest)(nil), "panacea.datapool.v2.QueryPoolRequest")
 	proto.RegisterType((*QueryPoolResponse)(nil), "panacea.datapool.v2.QueryPoolResponse")
 	proto.RegisterType((*QueryDataValidatorRequest)(nil), "panacea.datapool.v2.QueryDataValidatorRequest")
 	proto.RegisterType((*QueryDataValidatorResponse)(nil), "panacea.datapool.v2.QueryDataValidatorResponse")
+	proto.RegisterType((*QueryDataPoolParamsRequest)(nil), "panacea.datapool.v2.QueryDataPoolParamsRequest")
+	proto.RegisterType((*QueryDataPoolParamsResponse)(nil), "panacea.datapool.v2.QueryDataPoolParamsResponse")
 }
 
 func init() { proto.RegisterFile("panacea/datapool/v2/query.proto", fileDescriptor_f3fda93d2b4f4508) }
 
 var fileDescriptor_f3fda93d2b4f4508 = []byte{
-	// 384 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x92, 0xcd, 0x4a, 0xeb, 0x40,
-	0x14, 0xc7, 0x9b, 0xd2, 0xdb, 0x72, 0xe7, 0xd2, 0x8b, 0x8e, 0x0b, 0xdb, 0x20, 0x51, 0xa2, 0x2d,
-	0x42, 0x6d, 0x06, 0x23, 0xbe, 0x40, 0x71, 0x53, 0xdc, 0x68, 0x17, 0x2e, 0xdc, 0x94, 0x69, 0x66,
-	0x88, 0x81, 0x34, 0x27, 0xcd, 0x4c, 0x8b, 0x45, 0xdc, 0xe8, 0x0b, 0x08, 0xae, 0x7d, 0x04, 0xdf,
-	0xc3, 0x65, 0xc1, 0x8d, 0x4b, 0x69, 0x7d, 0x10, 0xc9, 0x34, 0xc1, 0x56, 0x52, 0x74, 0x79, 0x38,
-	0xff, 0x8f, 0x1f, 0x67, 0x06, 0x6d, 0x87, 0x34, 0xa0, 0x0e, 0xa7, 0x84, 0x51, 0x49, 0x43, 0x00,
-	0x9f, 0x8c, 0x6c, 0x32, 0x18, 0xf2, 0x68, 0x6c, 0x85, 0x11, 0x48, 0xc0, 0x1b, 0x89, 0xc0, 0x4a,
-	0x05, 0xd6, 0xc8, 0xd6, 0xb7, 0x5c, 0x00, 0xd7, 0xe7, 0x84, 0x86, 0x1e, 0xa1, 0x41, 0x00, 0x92,
-	0x4a, 0x0f, 0x02, 0x31, 0xb7, 0xe8, 0x46, 0x56, 0xa6, 0xb2, 0xaa, 0xbd, 0xd9, 0x40, 0x6b, 0xe7,
-	0x71, 0xc3, 0x19, 0x80, 0xdf, 0xe1, 0x83, 0x21, 0x17, 0x12, 0x6f, 0xa2, 0x52, 0xac, 0xe8, 0x7a,
-	0xac, 0xa2, 0xed, 0x68, 0xfb, 0x85, 0x4e, 0x31, 0x1e, 0xdb, 0xcc, 0x6c, 0xa1, 0xf5, 0x05, 0xb1,
-	0x08, 0x21, 0x10, 0x1c, 0x37, 0x51, 0x21, 0x5e, 0x2b, 0xe9, 0x3f, 0xbb, 0x6a, 0x65, 0x30, 0x5a,
-	0xca, 0xa0, 0x64, 0xe6, 0x31, 0xaa, 0xaa, 0x8c, 0x13, 0x2a, 0xe9, 0x05, 0xf5, 0x3d, 0x46, 0x25,
-	0x44, 0x69, 0x73, 0x05, 0x95, 0x28, 0x63, 0x11, 0x17, 0x42, 0xc5, 0xfd, 0xed, 0xa4, 0xa3, 0xe9,
-	0x22, 0x3d, 0xcb, 0x96, 0x30, 0xb4, 0xd1, 0xff, 0xb8, 0xae, 0x3b, 0x4a, 0x37, 0x09, 0x8d, 0x99,
-	0x49, 0xb3, 0x9c, 0x51, 0x66, 0x8b, 0xa3, 0xfd, 0x9c, 0x47, 0x7f, 0x54, 0x13, 0xbe, 0xd7, 0x50,
-	0x21, 0x06, 0xc7, 0xb5, 0xcc, 0x94, 0xef, 0x67, 0xd3, 0xeb, 0x3f, 0xc9, 0xe6, 0xb0, 0xe6, 0xc1,
-	0xdd, 0xeb, 0xc7, 0x63, 0xbe, 0x8e, 0xf7, 0xc8, 0xaa, 0xb7, 0x11, 0xe4, 0x26, 0x79, 0x80, 0x5b,
-	0xfc, 0xa4, 0xa1, 0xf2, 0x12, 0x30, 0xb6, 0x56, 0xf7, 0x64, 0x1d, 0x55, 0x27, 0xbf, 0xd6, 0x27,
-	0x80, 0x0d, 0x05, 0x58, 0xc3, 0xbb, 0x99, 0x80, 0xcb, 0x87, 0x6e, 0x9d, 0xbe, 0x4c, 0x0d, 0x6d,
-	0x32, 0x35, 0xb4, 0xf7, 0xa9, 0xa1, 0x3d, 0xcc, 0x8c, 0xdc, 0x64, 0x66, 0xe4, 0xde, 0x66, 0x46,
-	0xee, 0xf2, 0xd0, 0xf5, 0xe4, 0xd5, 0xb0, 0x67, 0x39, 0xd0, 0x27, 0x7d, 0xce, 0xbc, 0x9e, 0x0f,
-	0x4e, 0x9a, 0xd8, 0x74, 0x20, 0xe2, 0xe4, 0xfa, 0x2b, 0x58, 0x8e, 0x43, 0x2e, 0x7a, 0x45, 0xf5,
-	0x29, 0x8f, 0x3e, 0x03, 0x00, 0x00, 0xff, 0xff, 0xdd, 0xc8, 0x2a, 0xe7, 0x0a, 0x03, 0x00, 0x00,
+	// 456 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0x31, 0x8f, 0xd3, 0x30,
+	0x14, 0xc7, 0x6b, 0x28, 0x3d, 0x61, 0x74, 0x27, 0x30, 0x03, 0x77, 0xe9, 0x11, 0xc0, 0xc7, 0x9d,
+	0x90, 0x4a, 0x63, 0x48, 0xc5, 0x17, 0xa8, 0x58, 0x2a, 0x96, 0x92, 0x81, 0x81, 0xa5, 0x72, 0x63,
+	0x2b, 0x44, 0x4a, 0xe3, 0x34, 0x76, 0x2b, 0x2a, 0xc4, 0x02, 0x5f, 0x00, 0x89, 0x85, 0x85, 0xef,
+	0xd3, 0xb1, 0x12, 0x0b, 0x23, 0x6a, 0xf9, 0x20, 0x28, 0x8e, 0x23, 0x1a, 0x70, 0xd5, 0x8e, 0x2f,
+	0xef, 0xff, 0xff, 0xbf, 0x5f, 0xde, 0x4b, 0xe0, 0x83, 0x8c, 0xa6, 0x34, 0xe4, 0x94, 0x30, 0xaa,
+	0x68, 0x26, 0x44, 0x42, 0xe6, 0x3e, 0x99, 0xce, 0x78, 0xbe, 0xf0, 0xb2, 0x5c, 0x28, 0x81, 0xee,
+	0x1a, 0x81, 0x57, 0x09, 0xbc, 0xb9, 0xef, 0x9c, 0x47, 0x42, 0x44, 0x09, 0x27, 0x34, 0x8b, 0x09,
+	0x4d, 0x53, 0xa1, 0xa8, 0x8a, 0x45, 0x2a, 0x4b, 0x8b, 0xe3, 0xda, 0x32, 0xb5, 0xb5, 0xec, 0x3f,
+	0xb2, 0xf5, 0x23, 0x9e, 0x72, 0x19, 0x9b, 0x08, 0xdc, 0x81, 0xb7, 0x5f, 0x17, 0x10, 0x43, 0x21,
+	0x92, 0x80, 0x4f, 0x67, 0x5c, 0x2a, 0x74, 0x0f, 0x1e, 0x15, 0xe2, 0x51, 0xcc, 0x4e, 0xc1, 0x43,
+	0xf0, 0xa4, 0x19, 0xb4, 0x8a, 0x72, 0xc0, 0x70, 0x1f, 0xde, 0xd9, 0x12, 0xcb, 0x4c, 0xa4, 0x92,
+	0xa3, 0x2e, 0x6c, 0x16, 0x6d, 0x2d, 0xbd, 0xe5, 0x9f, 0x79, 0x96, 0xd7, 0xf0, 0xb4, 0x41, 0xcb,
+	0xf0, 0x0b, 0x78, 0xa6, 0x33, 0x5e, 0x52, 0x45, 0xdf, 0xd0, 0x24, 0x66, 0x54, 0x89, 0xbc, 0x9a,
+	0x7c, 0x0a, 0x8f, 0x28, 0x63, 0x39, 0x97, 0x52, 0xc7, 0xdd, 0x0c, 0xaa, 0x12, 0x47, 0xd0, 0xb1,
+	0xd9, 0x0c, 0xc3, 0x00, 0x9e, 0x14, 0xe3, 0x46, 0xf3, 0xaa, 0x63, 0x68, 0xb0, 0x95, 0xa6, 0x9e,
+	0x71, 0xcc, 0xb6, 0x4b, 0x7c, 0xbe, 0x35, 0xa8, 0xc0, 0x1e, 0xd2, 0x9c, 0x4e, 0xa4, 0x01, 0xc4,
+	0x01, 0x6c, 0x5b, 0xbb, 0x86, 0xa3, 0x07, 0x5b, 0x99, 0x7e, 0x62, 0xe6, 0xb7, 0xed, 0xdb, 0x28,
+	0x4d, 0x46, 0xea, 0x2f, 0xaf, 0xc3, 0x1b, 0x3a, 0x14, 0x7d, 0x06, 0xb0, 0x59, 0xa4, 0xa2, 0x4b,
+	0xab, 0xef, 0xdf, 0x43, 0x39, 0x57, 0xfb, 0x64, 0x25, 0x16, 0x7e, 0xfa, 0xe9, 0xc7, 0xef, 0xaf,
+	0xd7, 0xae, 0xd0, 0x63, 0xb2, 0xeb, 0x83, 0x91, 0xe4, 0x83, 0x39, 0xf9, 0x47, 0xf4, 0x1d, 0xc0,
+	0xe3, 0xda, 0x8a, 0x90, 0xb7, 0x7b, 0x8e, 0xed, 0x8c, 0x0e, 0x39, 0x58, 0x6f, 0x00, 0x3b, 0x1a,
+	0xf0, 0x12, 0x5d, 0x58, 0x01, 0xeb, 0xa7, 0x45, 0xdf, 0x00, 0x3c, 0xa9, 0xef, 0x1f, 0xed, 0x19,
+	0xf8, 0xdf, 0x1d, 0x9d, 0x67, 0x87, 0x1b, 0x0c, 0xe2, 0x85, 0x46, 0xbc, 0x8f, 0xda, 0xf6, 0x1d,
+	0x6a, 0x71, 0xff, 0xd5, 0x72, 0xed, 0x82, 0xd5, 0xda, 0x05, 0xbf, 0xd6, 0x2e, 0xf8, 0xb2, 0x71,
+	0x1b, 0xab, 0x8d, 0xdb, 0xf8, 0xb9, 0x71, 0x1b, 0x6f, 0x9f, 0x47, 0xb1, 0x7a, 0x37, 0x1b, 0x7b,
+	0xa1, 0x98, 0x90, 0x09, 0x67, 0xf1, 0x38, 0x11, 0x61, 0x95, 0xd4, 0x0d, 0x45, 0xce, 0xc9, 0xfb,
+	0xbf, 0x81, 0x6a, 0x91, 0x71, 0x39, 0x6e, 0xe9, 0x3f, 0xb4, 0xf7, 0x27, 0x00, 0x00, 0xff, 0xff,
+	0xc3, 0x89, 0x7c, 0xf9, 0x3a, 0x04, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -261,6 +350,8 @@ type QueryClient interface {
 	Pool(ctx context.Context, in *QueryPoolRequest, opts ...grpc.CallOption) (*QueryPoolResponse, error)
 	// DataValidator returns a DataValidator.
 	DataValidator(ctx context.Context, in *QueryDataValidatorRequest, opts ...grpc.CallOption) (*QueryDataValidatorResponse, error)
+	// DataPoolParams returns params of x/datapool module
+	DataPoolParams(ctx context.Context, in *QueryDataPoolParamsRequest, opts ...grpc.CallOption) (*QueryDataPoolParamsResponse, error)
 }
 
 type queryClient struct {
@@ -289,12 +380,23 @@ func (c *queryClient) DataValidator(ctx context.Context, in *QueryDataValidatorR
 	return out, nil
 }
 
+func (c *queryClient) DataPoolParams(ctx context.Context, in *QueryDataPoolParamsRequest, opts ...grpc.CallOption) (*QueryDataPoolParamsResponse, error) {
+	out := new(QueryDataPoolParamsResponse)
+	err := c.cc.Invoke(ctx, "/panacea.datapool.v2.Query/DataPoolParams", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// Pool returns a Pool.
 	Pool(context.Context, *QueryPoolRequest) (*QueryPoolResponse, error)
 	// DataValidator returns a DataValidator.
 	DataValidator(context.Context, *QueryDataValidatorRequest) (*QueryDataValidatorResponse, error)
+	// DataPoolParams returns params of x/datapool module
+	DataPoolParams(context.Context, *QueryDataPoolParamsRequest) (*QueryDataPoolParamsResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -306,6 +408,9 @@ func (*UnimplementedQueryServer) Pool(ctx context.Context, req *QueryPoolRequest
 }
 func (*UnimplementedQueryServer) DataValidator(ctx context.Context, req *QueryDataValidatorRequest) (*QueryDataValidatorResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DataValidator not implemented")
+}
+func (*UnimplementedQueryServer) DataPoolParams(ctx context.Context, req *QueryDataPoolParamsRequest) (*QueryDataPoolParamsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DataPoolParams not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -348,6 +453,24 @@ func _Query_DataValidator_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_DataPoolParams_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryDataPoolParamsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).DataPoolParams(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/panacea.datapool.v2.Query/DataPoolParams",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).DataPoolParams(ctx, req.(*QueryDataPoolParamsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "panacea.datapool.v2.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -359,6 +482,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DataValidator",
 			Handler:    _Query_DataValidator_Handler,
+		},
+		{
+			MethodName: "DataPoolParams",
+			Handler:    _Query_DataPoolParams_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -493,6 +620,64 @@ func (m *QueryDataValidatorResponse) MarshalToSizedBuffer(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryDataPoolParamsRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryDataPoolParamsRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryDataPoolParamsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryDataPoolParamsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryDataPoolParamsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryDataPoolParamsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Params != nil {
+		{
+			size, err := m.Params.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -550,6 +735,28 @@ func (m *QueryDataValidatorResponse) Size() (n int) {
 	_ = l
 	if m.DataValidator != nil {
 		l = m.DataValidator.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryDataPoolParamsRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryDataPoolParamsResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Params != nil {
+		l = m.Params.Size()
 		n += 1 + l + sovQuery(uint64(l))
 	}
 	return n
@@ -860,6 +1067,142 @@ func (m *QueryDataValidatorResponse) Unmarshal(dAtA []byte) error {
 				m.DataValidator = &DataValidator{}
 			}
 			if err := m.DataValidator.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryDataPoolParamsRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryDataPoolParamsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryDataPoolParamsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryDataPoolParamsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryDataPoolParamsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryDataPoolParamsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Params", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Params == nil {
+				m.Params = &Params{}
+			}
+			if err := m.Params.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/datapool/types/query.pb.gw.go
+++ b/x/datapool/types/query.pb.gw.go
@@ -121,6 +121,24 @@ func local_request_Query_DataValidator_0(ctx context.Context, marshaler runtime.
 
 }
 
+func request_Query_DataPoolParams_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryDataPoolParamsRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.DataPoolParams(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_DataPoolParams_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryDataPoolParamsRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.DataPoolParams(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -164,6 +182,26 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_DataValidator_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_DataPoolParams_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_DataPoolParams_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_DataPoolParams_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -248,6 +286,26 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_DataPoolParams_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_DataPoolParams_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_DataPoolParams_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -255,10 +313,14 @@ var (
 	pattern_Query_Pool_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"panacea", "datapool", "v2", "pools", "pool_id"}, "", runtime.AssumeColonVerbOpt(true)))
 
 	pattern_Query_DataValidator_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"panacea", "datapool", "v2", "data_validator"}, "", runtime.AssumeColonVerbOpt(true)))
+
+	pattern_Query_DataPoolParams_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"panacea", "datapool", "v2", "params"}, "", runtime.AssumeColonVerbOpt(true)))
 )
 
 var (
 	forward_Query_Pool_0 = runtime.ForwardResponseMessage
 
 	forward_Query_DataValidator_0 = runtime.ForwardResponseMessage
+
+	forward_Query_DataPoolParams_0 = runtime.ForwardResponseMessage
 )


### PR DESCRIPTION
Implemented query params of datapool module. 
It may be used to get NFT contract address registered on `x/datapool` module
