### PR TITLE
chore: Fix typo and refactor parameter name in Deal model.

### DIFF
--- a/x/datadeal/client/cli/queryDeal.go
+++ b/x/datadeal/client/cli/queryDeal.go
@@ -1,16 +1,17 @@
 package cli
 
 import (
+	"strconv"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/medibloc/panacea-core/v2/x/datadeal/types"
 	"github.com/spf13/cobra"
-	"strconv"
 )
 
 func CmdGetDeal() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get-deal [dealId]",
+		Use:   "deal [deal-id]",
 		Short: "Query a deal",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/datadeal/client/cli/testdata/create_deal_file.json
+++ b/x/datadeal/client/cli/testdata/create_deal_file.json
@@ -1,5 +1,5 @@
 {
-  "data_schmea": [
+  "data_schema": [
     "https://www.json.ld"
   ],
   "budget": "10000000umed",

--- a/x/datadeal/client/cli/txDeal.go
+++ b/x/datadeal/client/cli/txDeal.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"strconv"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -12,8 +15,6 @@ import (
 	"github.com/medibloc/panacea-core/v2/x/datadeal/types"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
-	"io/ioutil"
-	"strconv"
 )
 
 func CmdCreateDeal() *cobra.Command {
@@ -73,7 +74,7 @@ func CmdSellData() *cobra.Command {
 
 func CmdDeactivateDeal() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "deactivate-deal [dealId]",
+		Use:   "deactivate-deal [deal-id]",
 		Short: "deactivate-deal",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/datadeal/keeper/deal.go
+++ b/x/datadeal/keeper/deal.go
@@ -175,10 +175,8 @@ func (k Keeper) SellOwnData(ctx sdk.Context, seller sdk.AccAddress, cert types.D
 		return sdk.Coin{}, err
 	}
 
-	//TODO: Fields max_num_data and cur_num_data will be changed in next data datadeal model.
 	totalAmount := findDeal.GetBudget().Amount.Uint64()
 	countOfData := findDeal.GetMaxNumData()
-
 	pricePerData := sdk.NewCoin(assets.MicroMedDenom, sdk.NewIntFromUint64(totalAmount/countOfData))
 
 	dealBalance := k.bankKeeper.GetBalance(ctx, dealAddress, assets.MicroMedDenom)

--- a/x/datadeal/types/deal.go
+++ b/x/datadeal/types/deal.go
@@ -2,10 +2,11 @@ package types
 
 import (
 	"fmt"
+	"strings"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/medibloc/panacea-core/v2/x/datadeal/v044_temp/address"
-	"strings"
 )
 
 func NewDealAddress(dealId uint64) sdk.AccAddress {

--- a/x/datadeal/types/genesis.go
+++ b/x/datadeal/types/genesis.go
@@ -5,7 +5,7 @@ func DefaultGenesis() *GenesisState {
 	return &GenesisState{
 		Deals:            map[uint64]*Deal{},
 		DataCertificates: map[string]*DataValidationCertificate{},
-		NextDealNumber:   1,
+		NextDealNumber:   uint64(1),
 	}
 }
 


### PR DESCRIPTION
- Change parameter name based on cosmos-sdk convention.
- Apply `gofmt` to some code.
- Fix typo in deal model