### PR TITLE
feat: fix upgradeHander issue

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -789,7 +789,7 @@ func initParamsKeeper(appCodec codec.BinaryMarshaler, legacyAmino *codec.LegacyA
 	return paramsKeeper
 }
 
-// registerUpgradeHandlers registers upgrade handlers, and sets the storetypes loader if necessary.
+// registerUpgradeHandlers registers upgrade handlers, and sets the store loader if necessary.
 // This function must be called before sealing the BaseApp (i.e. by app.LoadLatestVersion())
 // because the storetypes loader cannot be set if BaseApp is already sealed.
 func (app *App) registerUpgradeHandlers() error {

--- a/app/app.go
+++ b/app/app.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/server/api"
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -590,6 +591,11 @@ func New(
 	)
 	app.SetEndBlocker(app.EndBlocker)
 
+	err = app.registerUpgradeHandlers()
+	if err != nil {
+		panic("Failed to register upgradeHandler: " + err.Error())
+	}
+
 	if loadLatest {
 		if err := app.LoadLatestVersion(); err != nil {
 			tmos.Exit(err.Error())
@@ -614,8 +620,6 @@ func New(
 	app.ScopedIBCKeeper = scopedIBCKeeper
 	app.ScopedTransferKeeper = scopedTransferKeeper
 	app.ScopedWasmKeeper = scopedWasmKeeper
-
-	app.registerUpgradeHandlers()
 
 	return app
 }
@@ -785,7 +789,10 @@ func initParamsKeeper(appCodec codec.BinaryMarshaler, legacyAmino *codec.LegacyA
 	return paramsKeeper
 }
 
-func (app *App) registerUpgradeHandlers() {
+// registerUpgradeHandlers registers upgrade handlers, and sets the storetypes loader if necessary.
+// This function must be called before sealing the BaseApp (i.e. by app.LoadLatestVersion())
+// because the storetypes loader cannot be set if BaseApp is already sealed.
+func (app *App) registerUpgradeHandlers() error {
 	app.UpgradeKeeper.SetUpgradeHandler("v2.0.2", func(ctx sdk.Context, plan upgradetypes.Plan) {})
 
 	app.UpgradeKeeper.SetUpgradeHandler("v2.0.3", func(ctx sdk.Context, plan upgradetypes.Plan) {
@@ -819,9 +826,25 @@ func (app *App) registerUpgradeHandlers() {
 		}
 	})
 
-	app.UpgradeKeeper.SetUpgradeHandler("v2.1.0-alpha1", func(ctx sdk.Context, plan upgradetypes.Plan) {
+	app.UpgradeKeeper.SetUpgradeHandler("v2.1.0-alpha2", func(ctx sdk.Context, plan upgradetypes.Plan) {
 		datadeal.InitGenesis(ctx, app.dataDealKeeper, *datadealtypes.DefaultGenesis())
 		datapool.InitGenesis(ctx, app.dataPoolKeeper, *datapooltypes.DefaultGenesis())
 		oracle.InitGenesis(ctx, app.oracleKeeper, *oracletypes.DefaultGenesis())
 	})
+
+	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		return err
+	}
+
+	if upgradeInfo.Name == "v2.1.0-alpha2" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{datadealtypes.ModuleName, datapooltypes.ModuleName, oracletypes.ModuleName},
+		}
+
+		// configure storetypes loader that checks if version == upgradeHeight and applies storetypes upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/pborman/uuid v1.2.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rakyll/statik v0.1.7
-	github.com/regen-network/cosmos-proto v0.3.1 // indirect
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
We ran into an error situation during the Testnet deployment.
```
Jun 10 03:09:17 testnet-sentry panacead[3707341]: panic: cannot delete latest saved version (12)
Jun 10 03:09:17 testnet-sentry panacead[3707341]: goroutine 1 [running]:
Jun 10 03:09:17 testnet-sentry panacead[3707341]: github.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).pruneStores(0xc0001cc460)
Jun 10 03:09:17 testnet-sentry panacead[3707341]:         /home/ubuntu/go/pkg/mod/github.com/medibloc/cosmos-sdk@v0.42.11-panacea.1/store/rootmulti/store.go:388 +0x26e
```

This error occurs when the following code is excuted.
https://github.com/cosmos/cosmos-sdk/blob/v0.42.11/store/rootmulti/store.go#L380

CosmosHub has solved this related problem as follows.
https://github.com/cosmos/gaia/blob/v5.0.8/app/app.go#L428

We also modified it with reference to this.