### PR TITLE
feat: added cipher text decrypt function

### DIFF
--- a/client/decrypt/decrypt.go
+++ b/client/decrypt/decrypt.go
@@ -1,0 +1,102 @@
+package decrypt
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/tendermint/btcd/btcec"
+	"github.com/tendermint/tendermint/libs/cli"
+	"io/ioutil"
+)
+
+const (
+	FlagCipherText     = "text"
+	FlagCipherTextPath = "path"
+)
+
+func Command(defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "decrypt [name] (--text [ciphertext] | --path [ciphertext-file])",
+		Short: "Decrypt and output the ciphertext file encrypted with ECDSA PublicKey.",
+		Long: `This command can decrypt ciphertext encrypted with ECDSA PublicKey. 
+The file contents must be Standard Base64 encoded.
+Also, make sure your key is stored in the localStore.
+(According to the following command (panacead keys add ...)
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+
+			privKeyHex, err := keyring.NewUnsafe(clientCtx.Keyring).UnsafeExportPrivKeyHex(args[0])
+			if err != nil {
+				return err
+			}
+
+			privKey, err := hex.DecodeString(privKeyHex)
+			if err != nil {
+				return err
+			}
+
+			content, err := getContent(cmd.Flags())
+
+			if err != nil {
+				return fmt.Errorf("failed read cipherText. %w", err)
+			}
+
+			ecdsaPrivKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), privKey)
+			decodeText, err := base64.StdEncoding.DecodeString(content)
+			if err != nil {
+				return err
+			}
+			plainText, err := btcec.Decrypt(ecdsaPrivKey, decodeText)
+			if err != nil {
+				return err
+			}
+
+			cmd.Println(string(plainText))
+
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+	cmd.PersistentFlags().String(flags.FlagKeyringDir, "", "The client Keyring directory; if omitted, the default 'home' directory will be used")
+	cmd.PersistentFlags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|test)")
+	cmd.PersistentFlags().String(cli.OutputFlag, "text", "Output format (text|json)")
+	cmd.Flags().String(FlagCipherText, "", "Standard Base64-encoded ciphertext")
+	cmd.Flags().String(FlagCipherTextPath, "", "File path where Standard Base64-encoded ciphertext is stored")
+
+	return cmd
+}
+
+func getContent(flag *pflag.FlagSet) (string, error) {
+	cipherText, err := flag.GetString(FlagCipherText)
+	if err != nil {
+		return "", err
+	}
+	cipherTextPath, err := flag.GetString(FlagCipherTextPath)
+	if err != nil {
+		return "", err
+	}
+
+	if len(cipherText) == 0 && len(cipherTextPath) == 0 {
+		return "", fmt.Errorf("either --text or --path should be required")
+	} else if len(cipherText) != 0 && len(cipherTextPath) != 0 {
+		return "", fmt.Errorf("only one of --text or --path should be specified")
+	}
+
+	if len(cipherText) != 0 {
+		return cipherText, nil
+	}
+
+	content, err := ioutil.ReadFile(cipherTextPath)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}

--- a/client/decrypt/decrypt.go
+++ b/client/decrypt/decrypt.go
@@ -14,13 +14,13 @@ import (
 )
 
 const (
-	FlagCipherText     = "text"
+	FlagCipherText     = "cipher-text"
 	FlagCipherTextPath = "path"
 )
 
 func Command(defaultNodeHome string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "decrypt [name] (--text [ciphertext] | --path [ciphertext-file])",
+		Use:   "decrypt [name] (--cipher-text [ciphertext] | --path [ciphertext-file])",
 		Short: "Decrypt and output the ciphertext file encrypted with ECDSA PublicKey.",
 		Long: `This command can decrypt ciphertext encrypted with ECDSA PublicKey. 
 And your key should be stored in the localStore.

--- a/client/decrypt/decrypt.go
+++ b/client/decrypt/decrypt.go
@@ -4,12 +4,12 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/tendermint/btcd/btcec"
 	"github.com/tendermint/tendermint/libs/cli"
 	"io/ioutil"
 )

--- a/cmd/panacead/cmd/root.go
+++ b/cmd/panacead/cmd/root.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	"github.com/medibloc/panacea-core/v2/app"
+	"github.com/medibloc/panacea-core/v2/client/decrypt"
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 )
@@ -106,6 +107,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		queryCommand(),
 		txCommand(),
 		keys.Commands(app.DefaultNodeHome),
+		decrypt.Command(app.DefaultNodeHome),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/CosmWasm/wasmd v0.21.0
+	github.com/btcsuite/btcd v0.22.0-beta
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/cosmos/cosmos-sdk v0.42.11
 	github.com/cosmos/go-bip39 v1.0.0
@@ -25,7 +26,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.1
-	github.com/tendermint/btcd v0.1.1
 	github.com/tendermint/tendermint v0.34.14
 	github.com/tendermint/tm-db v0.6.4
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.1
+	github.com/tendermint/btcd v0.1.1
 	github.com/tendermint/tendermint v0.34.14
 	github.com/tendermint/tm-db v0.6.4
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292


### PR DESCRIPTION
Closes #354 
The following features have been added.
* Added `panacead decrypt (--text {cipherText} | --path {cipherText file path}
* You can decrypt the encrypted text with the ECDSA-based publicKey using the privateKey stored in your local store.