### PR TITLE
fix: update Dockerfile for wasmvm v1.0.0-beta7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5-alpine3.14 AS build-env
+FROM golang:1.17-alpine3.14 AS build-env
 
 # Install minimum necessary dependencies,
 RUN set -eux; apk add --no-cache ca-certificates build-base;
@@ -16,8 +16,8 @@ COPY . /src/panacea-core
 WORKDIR /src/panacea-core
 
 # Get 'libwasmvm.so' from wasmvm
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta2/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
-RUN sha256sum /lib/libwasmvm_muslc.a | grep 3f5de8df9c6b606b4211f90edd681c84b0ecd870fdbf50678b6d9afd783a571c
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta7/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
+RUN sha256sum /lib/libwasmvm_muslc.a | grep d0152067a5609bfdfb3f0d5d6c0f2760f79d5f2cd7fd8513cafa9932d22eb350
 
 RUN make clean && BUILD_TAGS=muslc make build
 


### PR DESCRIPTION
Currently, github action of `build and push docker image` is failed.
I missed Dockerfile when upgrading cosmwasm version, so I updated.