### PR TITLE
feat: add oracle registration vote queue

### DIFF
--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -45,9 +45,9 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-func (k Keeper) AddOracleRegistrationVoteQueue(ctx sdk.Context, addr sdk.AccAddress, endTime time.Time) {
+func (k Keeper) AddOracleRegistrationVoteQueue(ctx sdk.Context, uniqueID string, addr sdk.AccAddress, endTime time.Time) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.GetOracleRegistrationVoteQueueKey(addr, endTime), addr)
+	store.Set(types.GetOracleRegistrationVoteQueueKey(uniqueID, addr, endTime), addr)
 }
 
 func (k Keeper) GetEndOracleRegistrationVoteQueueIterator(ctx sdk.Context, endTime time.Time) sdk.Iterator {
@@ -55,7 +55,7 @@ func (k Keeper) GetEndOracleRegistrationVoteQueueIterator(ctx sdk.Context, endTi
 	return store.Iterator(types.OracleRegistrationVotesQueueKey, sdk.PrefixEndBytes(types.GetOracleRegistrationVoteQueueByTimeKey(endTime)))
 }
 
-func (k Keeper) RemoveOracleRegistrationVoteQueue(ctx sdk.Context, addr sdk.AccAddress, endTime time.Time) {
+func (k Keeper) RemoveOracleRegistrationVoteQueue(ctx sdk.Context, uniqueID string, addr sdk.AccAddress, endTime time.Time) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.GetOracleRegistrationVoteQueueKey(addr, endTime))
+	store.Delete(types.GetOracleRegistrationVoteQueueKey(uniqueID, addr, endTime))
 }

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/tendermint/tendermint/libs/log"
 
@@ -42,4 +43,19 @@ func NewKeeper(
 
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
+}
+
+func (k Keeper) AddOracleRegistrationVoteQueue(ctx sdk.Context, addr sdk.AccAddress, endTime time.Time) {
+	store := ctx.KVStore(k.storeKey)
+	store.Set(types.GetOracleRegistrationVoteQueueKey(addr, endTime), addr)
+}
+
+func (k Keeper) GetEndOracleRegistrationVoteQueueIterator(ctx sdk.Context, endTime time.Time) sdk.Iterator {
+	store := ctx.KVStore(k.storeKey)
+	return store.Iterator(types.OracleRegistrationVotesQueueKey, sdk.PrefixEndBytes(types.GetOracleRegistrationVoteQueueByTimeKey(endTime)))
+}
+
+func (k Keeper) RemoveOracleRegistrationVoteQueue(ctx sdk.Context, addr sdk.AccAddress, endTime time.Time) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(types.GetOracleRegistrationVoteQueueKey(addr, endTime))
 }

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -50,7 +50,7 @@ func (k Keeper) AddOracleRegistrationVoteQueue(ctx sdk.Context, uniqueID string,
 	store.Set(types.GetOracleRegistrationVoteQueueKey(uniqueID, addr, endTime), addr)
 }
 
-func (k Keeper) GetEndOracleRegistrationVoteQueueIterator(ctx sdk.Context, endTime time.Time) sdk.Iterator {
+func (k Keeper) GetClosedOracleRegistrationVoteQueueIterator(ctx sdk.Context, endTime time.Time) sdk.Iterator {
 	store := ctx.KVStore(k.storeKey)
 	return store.Iterator(types.OracleRegistrationVotesQueueKey, sdk.PrefixEndBytes(types.GetOracleRegistrationVoteQueueByTimeKey(endTime)))
 }

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -33,8 +33,8 @@ func TestKeeperTestSuite(t *testing.T) {
 
 func (m keeperTestSuite) TestEndVoteQueue() {
 	now := time.Now()
-	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, oracle2Acc, now.Add(3*time.Second))
 	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, oracle1Acc, now.Add(1*time.Second))
+	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, oracle2Acc, now.Add(3*time.Second))
 	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, oracle3Acc, now.Add(5*time.Second))
 
 	iter := m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now)

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -1,0 +1,82 @@
+package keeper_test
+
+import (
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/medibloc/panacea-core/v2/types/testsuite"
+	"github.com/stretchr/testify/suite"
+	"testing"
+	"time"
+)
+
+var (
+	oracle1PrivKey = secp256k1.GenPrivKey()
+	oracle1PubKey  = oracle1PrivKey.PubKey()
+	oracle1Acc     = sdk.AccAddress(oracle1PubKey.Address())
+
+	oracle2PrivKey = secp256k1.GenPrivKey()
+	oracle2PubKey  = oracle2PrivKey.PubKey()
+	oracle2Acc     = sdk.AccAddress(oracle2PubKey.Address())
+
+	oracle3PrivKey = secp256k1.GenPrivKey()
+	oracle3PubKey  = oracle3PrivKey.PubKey()
+	oracle3Acc     = sdk.AccAddress(oracle3PubKey.Address())
+)
+
+type keeperTestSuite struct {
+	testsuite.TestSuite
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(keeperTestSuite))
+}
+
+func (m keeperTestSuite) TestEndVoteQueue() {
+	now := time.Now()
+	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, oracle2Acc, now.Add(3*time.Second))
+	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, oracle1Acc, now.Add(1*time.Second))
+	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, oracle3Acc, now.Add(5*time.Second))
+
+	iter := m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now)
+	m.Require().False(iter.Valid())
+
+	iter = m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(2*time.Second))
+
+	addrList := make([]sdk.AccAddress, 0)
+	for ; iter.Valid(); iter.Next() {
+		addrList = append(addrList, iter.Value())
+	}
+	m.Require().Equal(1, len(addrList))
+	m.Require().Equal(oracle1Acc, addrList[0])
+
+	iter = m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(4*time.Second))
+	addrList = make([]sdk.AccAddress, 0)
+	for ; iter.Valid(); iter.Next() {
+		addrList = append(addrList, iter.Value())
+	}
+	m.Require().Equal(2, len(addrList))
+	m.Require().Equal(oracle1Acc, addrList[0])
+	m.Require().Equal(oracle2Acc, addrList[1])
+
+	iter = m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(6*time.Second))
+	addrList = make([]sdk.AccAddress, 0)
+	for ; iter.Valid(); iter.Next() {
+		addrList = append(addrList, iter.Value())
+	}
+	m.Require().Equal(3, len(addrList))
+	m.Require().Equal(oracle1Acc, addrList[0])
+	m.Require().Equal(oracle2Acc, addrList[1])
+	m.Require().Equal(oracle3Acc, addrList[2])
+
+	// remove first queue and check
+	m.OracleKeeper.RemoveOracleRegistrationVoteQueue(m.Ctx, oracle1Acc, now.Add(1*time.Second))
+
+	iter = m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(6*time.Second))
+	addrList = make([]sdk.AccAddress, 0)
+	for ; iter.Valid(); iter.Next() {
+		addrList = append(addrList, iter.Value())
+	}
+	m.Require().Equal(2, len(addrList))
+	m.Require().Equal(oracle2Acc, addrList[0])
+	m.Require().Equal(oracle3Acc, addrList[1])
+}

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -37,10 +37,10 @@ func (m keeperTestSuite) TestEndVoteQueue() {
 	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, uniqueID, oracle2Acc, now.Add(3*time.Second))
 	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, uniqueID, oracle3Acc, now.Add(5*time.Second))
 
-	iter := m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now)
+	iter := m.OracleKeeper.GetClosedOracleRegistrationVoteQueueIterator(m.Ctx, now)
 	m.Require().False(iter.Valid())
 
-	iter = m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(2*time.Second))
+	iter = m.OracleKeeper.GetClosedOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(2*time.Second))
 
 	addrList := make([]sdk.AccAddress, 0)
 	for ; iter.Valid(); iter.Next() {
@@ -49,7 +49,7 @@ func (m keeperTestSuite) TestEndVoteQueue() {
 	m.Require().Equal(1, len(addrList))
 	m.Require().Equal(oracle1Acc, addrList[0])
 
-	iter = m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(4*time.Second))
+	iter = m.OracleKeeper.GetClosedOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(4*time.Second))
 	addrList = make([]sdk.AccAddress, 0)
 	for ; iter.Valid(); iter.Next() {
 		addrList = append(addrList, iter.Value())
@@ -58,7 +58,7 @@ func (m keeperTestSuite) TestEndVoteQueue() {
 	m.Require().Equal(oracle1Acc, addrList[0])
 	m.Require().Equal(oracle2Acc, addrList[1])
 
-	iter = m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(6*time.Second))
+	iter = m.OracleKeeper.GetClosedOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(6*time.Second))
 	addrList = make([]sdk.AccAddress, 0)
 	for ; iter.Valid(); iter.Next() {
 		addrList = append(addrList, iter.Value())
@@ -71,7 +71,7 @@ func (m keeperTestSuite) TestEndVoteQueue() {
 	// remove first queue and check
 	m.OracleKeeper.RemoveOracleRegistrationVoteQueue(m.Ctx, uniqueID, oracle1Acc, now.Add(1*time.Second))
 
-	iter = m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(6*time.Second))
+	iter = m.OracleKeeper.GetClosedOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(6*time.Second))
 	addrList = make([]sdk.AccAddress, 0)
 	for ; iter.Valid(); iter.Next() {
 		addrList = append(addrList, iter.Value())

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -33,9 +33,9 @@ func TestKeeperTestSuite(t *testing.T) {
 
 func (m keeperTestSuite) TestEndVoteQueue() {
 	now := time.Now()
-	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, oracle1Acc, now.Add(1*time.Second))
-	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, oracle2Acc, now.Add(3*time.Second))
-	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, oracle3Acc, now.Add(5*time.Second))
+	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, uniqueID, oracle1Acc, now.Add(1*time.Second))
+	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, uniqueID, oracle2Acc, now.Add(3*time.Second))
+	m.OracleKeeper.AddOracleRegistrationVoteQueue(m.Ctx, uniqueID, oracle3Acc, now.Add(5*time.Second))
 
 	iter := m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now)
 	m.Require().False(iter.Valid())
@@ -69,7 +69,7 @@ func (m keeperTestSuite) TestEndVoteQueue() {
 	m.Require().Equal(oracle3Acc, addrList[2])
 
 	// remove first queue and check
-	m.OracleKeeper.RemoveOracleRegistrationVoteQueue(m.Ctx, oracle1Acc, now.Add(1*time.Second))
+	m.OracleKeeper.RemoveOracleRegistrationVoteQueue(m.Ctx, uniqueID, oracle1Acc, now.Add(1*time.Second))
 
 	iter = m.OracleKeeper.GetEndOracleRegistrationVoteQueueIterator(m.Ctx, now.Add(6*time.Second))
 	addrList = make([]sdk.AccAddress, 0)

--- a/x/oracle/types/keys.go
+++ b/x/oracle/types/keys.go
@@ -45,8 +45,8 @@ func GetOracleRegistrationVoteKey(uniqueID string, votingTargetAddress, voterAdd
 	return append(OracleRegistrationVotesKey, CombineKeys([]byte(uniqueID), votingTargetAddress, voterAddress)...)
 }
 
-func GetOracleRegistrationVoteQueueKey(addr sdk.AccAddress, endTime time.Time) []byte {
-	return append(OracleRegistrationVotesQueueKey, CombineKeys(sdk.FormatTimeBytes(endTime), addr)...)
+func GetOracleRegistrationVoteQueueKey(uniqueID string, addr sdk.AccAddress, endTime time.Time) []byte {
+	return append(OracleRegistrationVotesQueueKey, CombineKeys(sdk.FormatTimeBytes(endTime), []byte(uniqueID), addr)...)
 }
 
 func GetOracleRegistrationVoteQueueByTimeKey(endTime time.Time) []byte {

--- a/x/oracle/types/keys.go
+++ b/x/oracle/types/keys.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"time"
 )
 
 const (
@@ -24,9 +25,10 @@ const (
 
 var (
 	// OraclesKey defines key to store oracle
-	OraclesKey                 = []byte{0x01}
-	OracleRegistrationsKey     = []byte{0x02}
-	OracleRegistrationVotesKey = []byte{0x03}
+	OraclesKey                      = []byte{0x01}
+	OracleRegistrationsKey          = []byte{0x02}
+	OracleRegistrationVotesKey      = []byte{0x03}
+	OracleRegistrationVotesQueueKey = []byte{0x04}
 
 	IndexSeparator = []byte{0xFF}
 )
@@ -41,6 +43,14 @@ func GetOracleRegistrationKey(address sdk.AccAddress) []byte {
 
 func GetOracleRegistrationVoteKey(uniqueID string, votingTargetAddress, voterAddress sdk.AccAddress) []byte {
 	return append(OracleRegistrationVotesKey, CombineKeys([]byte(uniqueID), votingTargetAddress, voterAddress)...)
+}
+
+func GetOracleRegistrationVoteQueueKey(addr sdk.AccAddress, endTime time.Time) []byte {
+	return append(OracleRegistrationVotesQueueKey, CombineKeys(sdk.FormatTimeBytes(endTime), addr)...)
+}
+
+func GetOracleRegistrationVoteQueueByTimeKey(endTime time.Time) []byte {
+	return append(OracleRegistrationVotesQueueKey, sdk.FormatTimeBytes(endTime)...)
 }
 
 func CombineKeys(keys ...[]byte) []byte {


### PR DESCRIPTION
### Implements
* Added queue to get list of `OracleRegistrationVotes` that have closed voting.
    * Only data whose time passed by the key is retrieved.

Reference link: https://github.com/cosmos/cosmos-sdk/blob/main/x/gov/keeper/keeper.go#L203