### PR TITLE
feat: Implement Emission of Register Oracle Event

### DIFF
--- a/x/datadeal/types/genesis.go
+++ b/x/datadeal/types/genesis.go
@@ -12,5 +12,6 @@ func DefaultGenesis() *GenesisState {
 // failure.
 func (gs GenesisState) Validate() error {
 	//panic("implements me")
+
 	return nil
 }

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -19,5 +19,6 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 	}
 
 	cmd.AddCommand(CmdGetParams())
+
 	return cmd
 }

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -17,7 +17,7 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
-	cmd.AddCommand(CmdGetParams())
 
+	cmd.AddCommand(CmdGetParams())
 	return cmd
 }

--- a/x/oracle/genesis.go
+++ b/x/oracle/genesis.go
@@ -30,7 +30,6 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	k.SetParams(ctx, genState.Params)
 
 	// TODO implements SetUpgradeInfo
-
 }
 
 // ExportGenesis returns the capability module's exported genesis.

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -15,10 +15,9 @@ import (
 
 type (
 	Keeper struct {
-		cdc      codec.Codec
-		storeKey sdk.StoreKey
-		memKey   sdk.StoreKey
-
+		cdc           codec.Codec
+		storeKey      sdk.StoreKey
+		memKey        sdk.StoreKey
 		paramSpace    paramtypes.Subspace
 		stakingKeeper types.StakingKeeper
 	}

--- a/x/oracle/keeper/oracle.go
+++ b/x/oracle/keeper/oracle.go
@@ -36,6 +36,7 @@ func (k Keeper) RegisterOracle(ctx sdk.Context, msg *types.MsgRegisterOracle) er
 			types.EventTypeRegisterOracle,
 			sdk.NewAttribute(types.AttributeKeyOracle, types.AttributeValueOracle)),
 	})
+
 	return nil
 }
 

--- a/x/oracle/keeper/oracle.go
+++ b/x/oracle/keeper/oracle.go
@@ -31,7 +31,11 @@ func (k Keeper) RegisterOracle(ctx sdk.Context, msg *types.MsgRegisterOracle) er
 
 	// TODO: Add active queue of Oracle Registration
 
-	// TODO: emit RegisterOracle event
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeRegisterOracle,
+			sdk.NewAttribute(types.AttributeKeyRegisterOracle, types.AttributeValueRegisterOracle)),
+	})
 	return nil
 }
 

--- a/x/oracle/keeper/oracle.go
+++ b/x/oracle/keeper/oracle.go
@@ -31,7 +31,11 @@ func (k Keeper) RegisterOracle(ctx sdk.Context, msg *types.MsgRegisterOracle) er
 
 	// TODO: Add active queue of Oracle Registration
 
-	// TODO: emit RegisterOracle event
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeRegisterOracle,
+			sdk.NewAttribute(types.AttributeKeyOracle, types.AttributeValueOracle)),
+	})
 	return nil
 }
 

--- a/x/oracle/keeper/oracle.go
+++ b/x/oracle/keeper/oracle.go
@@ -99,6 +99,7 @@ func (k Keeper) validateOracleRegistrationVote(ctx sdk.Context, vote *types.Orac
 	if err != nil {
 		return err
 	}
+
 	if oracle.Status != types.ORACLE_STATUS_ACTIVE {
 		return fmt.Errorf("this oracle is not in 'ACTIVE' state")
 	}

--- a/x/oracle/keeper/oracle.go
+++ b/x/oracle/keeper/oracle.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/medibloc/panacea-core/v2/x/oracle/types"
@@ -167,6 +166,7 @@ func (k Keeper) SetOracle(ctx sdk.Context, oracle *types.Oracle) error {
 		return err
 	}
 	key := types.GetOracleKey(accAddr)
+
 	bz, err := k.cdc.MarshalLengthPrefixed(oracle)
 	if err != nil {
 		return err
@@ -229,6 +229,7 @@ func (k Keeper) SetOracleRegistration(ctx sdk.Context, regOracle *types.OracleRe
 		return err
 	}
 	key := types.GetOracleRegistrationKey(accAddr)
+
 	bz, err := k.cdc.MarshalLengthPrefixed(regOracle)
 	if err != nil {
 		return err

--- a/x/oracle/keeper/oracle.go
+++ b/x/oracle/keeper/oracle.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/medibloc/panacea-core/v2/x/oracle/types"

--- a/x/oracle/keeper/oracle_test.go
+++ b/x/oracle/keeper/oracle_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"

--- a/x/oracle/keeper/oracle_test.go
+++ b/x/oracle/keeper/oracle_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 	"time"
 
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/medibloc/panacea-core/v2/types/testsuite"
 	"github.com/medibloc/panacea-core/v2/x/oracle/types"
 	"github.com/stretchr/testify/suite"

--- a/x/oracle/keeper/oracle_test.go
+++ b/x/oracle/keeper/oracle_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"

--- a/x/oracle/keeper/params_test.go
+++ b/x/oracle/keeper/params_test.go
@@ -21,6 +21,5 @@ func (suite *paramsTestSuite) TestSetAndGetParams() {
 	suite.OracleKeeper.SetParams(suite.Ctx, params)
 
 	getParams := suite.OracleKeeper.GetParams(suite.Ctx)
-
 	suite.Require().Equal(params, getParams)
 }

--- a/x/oracle/types/errors.go
+++ b/x/oracle/types/errors.go
@@ -3,7 +3,6 @@ package types
 import sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 // DONTCOVER
-
 var (
 	ErrOracleRegistrationVote      = sdkerrors.Register(ModuleName, 1, "error while voting for OracleRegistration")
 	ErrDetectionMaliciousBehavior  = sdkerrors.Register(ModuleName, 2, "errors caused by malicious actions")

--- a/x/oracle/types/event.go
+++ b/x/oracle/types/event.go
@@ -1,0 +1,10 @@
+package types
+
+const (
+	AttributeKeyRegisterOracle   = "oracle"
+	AttributeValueRegisterOracle = "RegisterOracleEvent"
+)
+
+var (
+	EventTypeRegisterOracle = "register"
+)

--- a/x/oracle/types/event.go
+++ b/x/oracle/types/event.go
@@ -1,17 +1,8 @@
 package types
 
 const (
-<<<<<<< HEAD
-	AttributeKeyRegisterOracle   = "oracle"
-	AttributeValueRegisterOracle = "RegisterOracleEvent"
-)
-
-var (
-	EventTypeRegisterOracle = "register"
-=======
 	EventTypeRegisterOracle = "register"
 
 	AttributeKeyOracle   = "oracle"
 	AttributeValueOracle = "RegisterOracleEvent"
->>>>>>> origin/ft/na/emit_event_register_oracle
 )

--- a/x/oracle/types/genesis.go
+++ b/x/oracle/types/genesis.go
@@ -36,6 +36,5 @@ func (m GenesisState) Validate() error {
 	if err := m.Params.Validate(); err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, err.Error())
 	}
-
 	return nil
 }

--- a/x/oracle/types/message_oracle.go
+++ b/x/oracle/types/message_oracle.go
@@ -53,8 +53,7 @@ func (msg *MsgRegisterOracle) ValidateBasic() error {
 }
 
 func (msg *MsgRegisterOracle) GetSignBytes() []byte {
-	bz := ModuleCdc.MustMarshalJSON(msg)
-	return sdk.MustSortJSON(bz)
+	panic("implemenets me")
 }
 
 func (msg *MsgRegisterOracle) GetSigners() []sdk.AccAddress {

--- a/x/oracle/types/message_oracle.go
+++ b/x/oracle/types/message_oracle.go
@@ -30,9 +30,6 @@ func (msg *MsgRegisterOracle) ValidateBasic() error {
 	if err := validateUniqueID(msg.UniqueId); err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid unique ID")
 	}
-	if len(msg.UniqueId) == 0 {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "unique ID cannot be empty")
-	}
 	if _, err := sdk.AccAddressFromBech32(msg.OracleAddress); err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid oracle address (%s)", err)
 	}
@@ -53,7 +50,8 @@ func (msg *MsgRegisterOracle) ValidateBasic() error {
 }
 
 func (msg *MsgRegisterOracle) GetSignBytes() []byte {
-	panic("implemenets me")
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
 }
 
 func (msg *MsgRegisterOracle) GetSigners() []sdk.AccAddress {

--- a/x/oracle/types/message_oracle.go
+++ b/x/oracle/types/message_oracle.go
@@ -30,6 +30,9 @@ func (msg *MsgRegisterOracle) ValidateBasic() error {
 	if err := validateUniqueID(msg.UniqueId); err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid unique ID")
 	}
+	if len(msg.UniqueId) == 0 {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "unique ID cannot be empty")
+	}
 	if _, err := sdk.AccAddressFromBech32(msg.OracleAddress); err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid oracle address (%s)", err)
 	}

--- a/x/oracle/types/oracle.go
+++ b/x/oracle/types/oracle.go
@@ -76,7 +76,21 @@ func (m OracleRegistration) ValidateBasic() error {
 	}
 
 	if m.TallyResult != nil {
+		if m.TallyResult.Yes.IsNegative() {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "yes in TallyResult must not be negative: %s", m.TallyResult.Yes)
+		}
 
+		if m.TallyResult.No.IsNegative() {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "no in TallyResult must not be negative: %s", m.TallyResult.Yes)
+		}
+
+		if m.TallyResult.InvalidYes.IsNegative() {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "invalidYes in TallyResult must not be negative: %s", m.TallyResult.Yes)
+		}
+
+		if m.TallyResult.ConsensusValue == nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "consensusValue in TallyResult must not be nil: %s", m.TallyResult.Yes)
+		}
 	}
 
 	return nil

--- a/x/oracle/types/oracle.go
+++ b/x/oracle/types/oracle.go
@@ -71,6 +71,14 @@ func (m OracleRegistration) ValidateBasic() error {
 		}
 	}
 
+	if m.VotingPeriod == nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "votingPeriod is nil")
+	}
+
+	if m.TallyResult != nil {
+
+	}
+
 	return nil
 }
 

--- a/x/oracle/types/params.go
+++ b/x/oracle/types/params.go
@@ -98,7 +98,6 @@ func validateUniqueID(i interface{}) error {
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Implement Emission of Register Oracle Event for subscribing in `panacea-doracle`.
- `EventType`, `AttributeKey`, and `AttributeValue` were implemented in `types/event.go`.
- For now, `AttributeValue` is `RegisterOracleEvent`.