### PR TITLE
chore: comment implement panic

### DIFF
--- a/x/datadeal/genesis.go
+++ b/x/datadeal/genesis.go
@@ -9,7 +9,7 @@ import (
 // InitGenesis initializes the capability module's state from a provided genesis
 // state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
-	panic("implements me")
+	//panic("implements me")
 }
 
 // ExportGenesis returns the capability module's exported genesis.

--- a/x/datadeal/types/genesis.go
+++ b/x/datadeal/types/genesis.go
@@ -11,5 +11,6 @@ func DefaultGenesis() *GenesisState {
 // Validate performs basic genesis state validation returning an error upon any
 // failure.
 func (gs GenesisState) Validate() error {
-	panic("implements me")
+	//panic("implements me")
+	return nil
 }


### PR DESCRIPTION
Current version of panacea cannot be initiated and started because panic occurs in validating and initiating the genesis of `datadeal` module. So I just commented them.