### PR TITLE
fix: oracle registration status check of RegisterOracle

### DIFF
--- a/x/oracle/keeper/oracle.go
+++ b/x/oracle/keeper/oracle.go
@@ -76,22 +76,23 @@ func (k Keeper) checkOracleRegistrationStatus(ctx sdk.Context, uniqueID, oracleA
 		return err
 	}
 
-	if existing.Status == types.ORACLE_REGISTRATION_STATUS_VOTING_PERIOD {
-		return fmt.Errorf("in voting period")
-	}
-
-	if existing.Status == types.ORACLE_REGISTRATION_STATUS_PASSED {
+	switch existing.Status {
+	case types.ORACLE_REGISTRATION_STATUS_PASSED:
 		oracle, err := k.GetOracle(ctx, oracleAddress)
 		if err != nil {
 			return err
 		}
-
 		if oracle.Status != types.ORACLE_STATUS_JAILED {
 			return fmt.Errorf("only jailed oracle can re-register oracle")
 		}
+		return nil
+	case types.ORACLE_REGISTRATION_STATUS_VOTING_PERIOD:
+		return fmt.Errorf("in voting period")
+	case types.ORACLE_REGISTRATION_STATUS_REJECTED:
+		return nil
+	default:
+		return fmt.Errorf("unexpected state. status: %s", existing.Status)
 	}
-
-	return nil
 }
 
 // VoteOracleRegistration defines to vote for the new oracle's verification results.

--- a/x/oracle/keeper/oracle.go
+++ b/x/oracle/keeper/oracle.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,7 +17,7 @@ func (k Keeper) RegisterOracle(ctx sdk.Context, msg *types.MsgRegisterOracle) er
 	}
 
 	// check if the oracle is active validator
-	if err := k.CheckValidatorStatus(ctx, oracleAccAddr); err != nil {
+	if err := k.checkValidatorStatus(ctx, oracleAccAddr); err != nil {
 		return sdkerrors.Wrapf(types.ErrRegisterOracle, err.Error())
 	}
 
@@ -24,6 +25,11 @@ func (k Keeper) RegisterOracle(ctx sdk.Context, msg *types.MsgRegisterOracle) er
 	params := k.GetParams(ctx)
 	if params.UniqueId != msg.UniqueId {
 		return sdkerrors.Wrapf(types.ErrRegisterOracle, "is not match the currently active uniqueID")
+	}
+
+	// check oracle status
+	if err := k.checkOracleRegistrationStatus(ctx, msg.UniqueId, msg.OracleAddress); err != nil {
+		return sdkerrors.Wrapf(types.ErrRegisterOracle, err.Error())
 	}
 
 	// store
@@ -46,8 +52,8 @@ func (k Keeper) RegisterOracle(ctx sdk.Context, msg *types.MsgRegisterOracle) er
 	return nil
 }
 
-// CheckValidatorStatus gets validator and check its status if it's eligible to be an oracle
-func (k Keeper) CheckValidatorStatus(ctx sdk.Context, oracleAccAddr sdk.AccAddress) error {
+// checkValidatorStatus gets validator and check its status if it's eligible to be an oracle
+func (k Keeper) checkValidatorStatus(ctx sdk.Context, oracleAccAddr sdk.AccAddress) error {
 	validator, found := k.stakingKeeper.GetValidator(ctx, sdk.ValAddress(oracleAccAddr))
 	if !found {
 		return types.ErrValidatorNotFound
@@ -55,6 +61,34 @@ func (k Keeper) CheckValidatorStatus(ctx sdk.Context, oracleAccAddr sdk.AccAddre
 
 	if validator.IsJailed() {
 		return types.ErrJailedValidator
+	}
+
+	return nil
+}
+
+// checkOracleRegistrationStatus checks the status of OracleRegistration and Oracle.
+func (k Keeper) checkOracleRegistrationStatus(ctx sdk.Context, uniqueID, oracleAddress string) error {
+	existing, err := k.GetOracleRegistration(ctx, uniqueID, oracleAddress)
+	if err != nil {
+		if errors.Is(err, types.ErrOracleRegistrationNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	if existing.Status == types.ORACLE_REGISTRATION_STATUS_VOTING_PERIOD {
+		return fmt.Errorf("in voting period")
+	}
+
+	if existing.Status == types.ORACLE_REGISTRATION_STATUS_PASSED {
+		oracle, err := k.GetOracle(ctx, oracleAddress)
+		if err != nil {
+			return err
+		}
+
+		if oracle.Status != types.ORACLE_STATUS_JAILED {
+			return fmt.Errorf("only jailed oracle can re-register oracle")
+		}
 	}
 
 	return nil
@@ -153,7 +187,7 @@ func (k Keeper) GetOracle(ctx sdk.Context, address string) (*types.Oracle, error
 	key := types.GetOracleKey(accAddr)
 	bz := store.Get(key)
 	if bz == nil {
-		return nil, fmt.Errorf(fmt.Sprintf("'%s' is not exist oracle", address))
+		return nil, fmt.Errorf(fmt.Sprintf("oracle '%s' does not exist", address))
 	}
 
 	oracle := &types.Oracle{}
@@ -214,7 +248,7 @@ func (k Keeper) GetOracleRegistration(ctx sdk.Context, uniqueID, address string)
 	key := types.GetOracleRegistrationKey(uniqueID, accAddr)
 	bz := store.Get(key)
 	if bz == nil {
-		return nil, fmt.Errorf("is not exist oracleRegistration with the address of '%s'", address)
+		return nil, types.ErrOracleRegistrationNotFound
 	}
 
 	oracleRegistration := &types.OracleRegistration{}

--- a/x/oracle/keeper/oracle_test.go
+++ b/x/oracle/keeper/oracle_test.go
@@ -199,6 +199,78 @@ func (suite oracleTestSuite) TestRegisterOracleFailedInvalidUniqueID() {
 	suite.Require().Error(err, types.ErrRegisterOracle)
 }
 
+func (suite oracleTestSuite) TestRegisterOracleFailedStatusVotingPeriod() {
+	ctx := suite.Ctx
+
+	suite.SetValidator(suite.oracleAccPubKey, sdk.NewInt(70))
+
+	votingOracleRegistration := &types.OracleRegistration{
+		UniqueId:               suite.uniqueID,
+		Address:                suite.oracleAccAddr.String(),
+		NodePubKey:             suite.nodePubKey.SerializeCompressed(),
+		NodePubKeyRemoteReport: suite.nodePubKeyRemoteReport,
+		TrustedBlockHeight:     suite.trustedBlockHeight,
+		TrustedBlockHash:       suite.trustedBlockHash,
+		Status:                 types.ORACLE_REGISTRATION_STATUS_VOTING_PERIOD,
+		VotingPeriod:           suite.OracleKeeper.GetVotingPeriod(ctx),
+	}
+
+	err := suite.OracleKeeper.SetOracleRegistration(ctx, votingOracleRegistration)
+	suite.Require().NoError(err)
+
+	msgRegisterOracle := &types.MsgRegisterOracle{
+		UniqueId:               suite.uniqueID,
+		OracleAddress:          suite.oracleAccAddr.String(),
+		NodePubKey:             suite.nodePubKey.SerializeCompressed(),
+		NodePubKeyRemoteReport: suite.nodePubKeyRemoteReport,
+		TrustedBlockHeight:     suite.trustedBlockHeight,
+		TrustedBlockHash:       suite.trustedBlockHash,
+	}
+
+	err = suite.OracleKeeper.RegisterOracle(ctx, msgRegisterOracle)
+	suite.Require().Error(err, types.ErrRegisterOracle)
+}
+
+func (suite oracleTestSuite) TestRegisterOracleFailedStatusPassedNotJailed() {
+	ctx := suite.Ctx
+
+	suite.SetValidator(suite.oracleAccPubKey, sdk.NewInt(70))
+
+	existingOracleRegistration := &types.OracleRegistration{
+		UniqueId:               suite.uniqueID,
+		Address:                suite.oracleAccAddr.String(),
+		NodePubKey:             suite.nodePubKey.SerializeCompressed(),
+		NodePubKeyRemoteReport: suite.nodePubKeyRemoteReport,
+		TrustedBlockHeight:     suite.trustedBlockHeight,
+		TrustedBlockHash:       suite.trustedBlockHash,
+		Status:                 types.ORACLE_REGISTRATION_STATUS_PASSED,
+		VotingPeriod:           suite.OracleKeeper.GetVotingPeriod(ctx),
+	}
+
+	err := suite.OracleKeeper.SetOracleRegistration(ctx, existingOracleRegistration)
+	suite.Require().NoError(err)
+
+	existingOracle := &types.Oracle{
+		Address: suite.oracleAccAddr.String(),
+		Status:  types.ORACLE_STATUS_ACTIVE,
+	}
+
+	err = suite.OracleKeeper.SetOracle(ctx, existingOracle)
+	suite.Require().NoError(err)
+
+	msgRegisterOracle := &types.MsgRegisterOracle{
+		UniqueId:               suite.uniqueID,
+		OracleAddress:          suite.oracleAccAddr.String(),
+		NodePubKey:             suite.nodePubKey.SerializeCompressed(),
+		NodePubKeyRemoteReport: suite.nodePubKeyRemoteReport,
+		TrustedBlockHeight:     suite.trustedBlockHeight,
+		TrustedBlockHash:       suite.trustedBlockHash,
+	}
+
+	err = suite.OracleKeeper.RegisterOracle(ctx, msgRegisterOracle)
+	suite.Require().Error(err, types.ErrRegisterOracle)
+}
+
 func (suite *oracleTestSuite) TestOracleRegistrationVoteSuccess() {
 	ctx := suite.Ctx
 

--- a/x/oracle/types/errors.go
+++ b/x/oracle/types/errors.go
@@ -17,4 +17,5 @@ var (
 	ErrRegisterOracle              = sdkerrors.Register(ModuleName, 10, "error while registering a oracle")
 	ErrValidatorNotFound           = sdkerrors.Register(ModuleName, 11, "validator not found")
 	ErrJailedValidator             = sdkerrors.Register(ModuleName, 12, "jailed validator cannot be a oracle")
+	ErrOracleRegistrationNotFound  = sdkerrors.Register(ModuleName, 13, "oracle registration not found")
 )


### PR DESCRIPTION
A validator, who can apply to be an oracle, could repeatedly request oracle registration regardless of the voting result. It results in the emission of event repeatedly to other oracles, and makes other oracles vote redundantly.

Thus, oracle registration vote can be opened only in the following cases.

- When applying for registration for the first time (not stored in `OracleRegistration` kv store)
- Applied but the previous vote is rejected (`OracleRegistration.Status` == `REJECTED`)
- When a registered oracle want to be shared the oracle private key again (e.g. delete `oracle_priv_key.sealed`) (`OracleRegistration.Status` == `PASSED` && `Oracle.Status` == `JAILED`)