### PR TITLE
feat: add nonce parameter in newMsgRegisterOracle func

### DIFF
--- a/x/oracle/client/cli/txRegisterOracle.go
+++ b/x/oracle/client/cli/txRegisterOracle.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"crypto/rand"
 	"encoding/base64"
+	"fmt"
+	"io"
 	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -43,7 +46,13 @@ func CmdRegisterOracle() *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgRegisterOracle(args[0], oracleAddress, nodePubKey, nodePubKeyRemoteReport, trustedBlockHeight, trustedBlockHash)
+			nonce := make([]byte, 12)
+			_, err = io.ReadFull(rand.Reader, nonce)
+			if err != nil {
+				return fmt.Errorf("failed to make nonce: %w", err)
+			}
+
+			msg := types.NewMsgRegisterOracle(args[0], oracleAddress, nodePubKey, nodePubKeyRemoteReport, trustedBlockHeight, trustedBlockHash, nonce)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/oracle/types/message_oracle.go
+++ b/x/oracle/types/message_oracle.go
@@ -7,7 +7,7 @@ import (
 
 var _ sdk.Msg = &MsgRegisterOracle{}
 
-func NewMsgRegisterOracle(uniqueID, oracleAddress string, nodePubKey, nodePubKeyRemoteReport []byte, trustedBlockHeight int64, trustedBlockHash []byte) *MsgRegisterOracle {
+func NewMsgRegisterOracle(uniqueID, oracleAddress string, nodePubKey, nodePubKeyRemoteReport []byte, trustedBlockHeight int64, trustedBlockHash, nonce []byte) *MsgRegisterOracle {
 	return &MsgRegisterOracle{
 		UniqueId:               uniqueID,
 		OracleAddress:          oracleAddress,
@@ -15,6 +15,7 @@ func NewMsgRegisterOracle(uniqueID, oracleAddress string, nodePubKey, nodePubKey
 		NodePubKeyRemoteReport: nodePubKeyRemoteReport,
 		TrustedBlockHeight:     trustedBlockHeight,
 		TrustedBlockHash:       trustedBlockHash,
+		Nonce:                  nonce,
 	}
 }
 


### PR DESCRIPTION
I added a missing field to the `NewMsgRegisterOracle` function.