### PR TITLE
ci: separate the Lint job with the main job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build (+ generating proto and docs)
       run: make build-all
@@ -28,13 +28,28 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Lint
-      uses: golangci/golangci-lint-action@v3
-      with:
-        version: v1.30
-
     - name: Publish coverage.html as an artifact
       uses: actions/upload-artifact@master
       with:
         name: coverage
         path: artifacts/coverage.html
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+        id: go
+
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout=5m


### PR DESCRIPTION
As the Lint job usually takes minutes, let's separate it with the main CI job, so that we can see the lint result quickly.