### PR TITLE
feat: add DeactivateDeal keeper and Tx CLI

### DIFF
--- a/x/datadeal/client/cli/tx.go
+++ b/x/datadeal/client/cli/tx.go
@@ -22,6 +22,7 @@ func GetTxCmd() *cobra.Command {
 	cmd.AddCommand(CmdSellData())
 	cmd.AddCommand(CmdVoteDataVerification())
 	cmd.AddCommand(CmdVoteDataDelivery())
+	cmd.AddCommand(CmdDeactivateDeal())
 
 	return cmd
 }

--- a/x/datadeal/client/cli/txDeactivateDeal.go
+++ b/x/datadeal/client/cli/txDeactivateDeal.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/medibloc/panacea-core/v2/x/datadeal/types"
+	"github.com/spf13/cobra"
+)
+
+func CmdDeactivateDeal() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deactivate-deal [dealID]",
+		Short: "Deactivate a deal",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			dealID, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				return err
+			}
+
+			requesterAddr := clientCtx.GetFromAddress()
+
+			msgDeactivateDeal := types.NewMsgDeactivateDeal(dealID, requesterAddr.String())
+
+			if err := msgDeactivateDeal.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msgDeactivateDeal)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/datadeal/keeper/deal.go
+++ b/x/datadeal/keeper/deal.go
@@ -482,3 +482,30 @@ func (k Keeper) RemoveDataDeliveryVote(ctx sdk.Context, vote *types.DataDelivery
 
 	return nil
 }
+
+func (k Keeper) DeactivateDeal(ctx sdk.Context, msg *types.MsgDeactivateDeal) error {
+	deal, err := k.GetDeal(ctx, msg.DealId)
+	if err != nil {
+		return sdkerrors.Wrapf(types.ErrDealDeactivate, err.Error())
+	}
+
+	if deal.BuyerAddress != msg.RequesterAddress {
+		return sdkerrors.Wrapf(types.ErrDealDeactivate, "invalid deactivate requester")
+	}
+
+	if deal.Status != types.DEAL_STATUS_ACTIVE {
+		return types.ErrDealNotActive
+	}
+
+	deal.Status = types.DEAL_STATUS_INACTIVE
+
+	err = k.SetDeal(ctx, deal)
+	if err != nil {
+		return sdkerrors.Wrapf(types.ErrDealDeactivate, err.Error())
+	}
+
+	//TODO: Implement Remove the DataVerification/DeliveryVote Queue after PR #449 merged
+	//https://github.com/medibloc/panacea-core/pull/449
+
+	return nil
+}

--- a/x/datadeal/keeper/deal.go
+++ b/x/datadeal/keeper/deal.go
@@ -490,11 +490,11 @@ func (k Keeper) DeactivateDeal(ctx sdk.Context, msg *types.MsgDeactivateDeal) er
 	}
 
 	if deal.BuyerAddress != msg.RequesterAddress {
-		return sdkerrors.Wrapf(types.ErrDealDeactivate, "invalid deactivate requester")
+		return sdkerrors.Wrapf(types.ErrDealDeactivate, "only buyer can deactivate deal")
 	}
 
 	if deal.Status != types.DEAL_STATUS_ACTIVE {
-		return types.ErrDealNotActive
+		return sdkerrors.Wrapf(types.ErrDealDeactivate, "deal's status is not 'ACTIVE'")
 	}
 
 	deal.Status = types.DEAL_STATUS_INACTIVE

--- a/x/datadeal/keeper/deal_test.go
+++ b/x/datadeal/keeper/deal_test.go
@@ -621,8 +621,6 @@ func (suite dealTestSuite) TestDataDeliveryVoteFaildInvalidStatus() {
 func (suite dealTestSuite) TestDeactivateDeal() {
 	ctx := suite.Ctx
 
-	_ = suite.MakeTestDeal(1, suite.buyerAccAddr)
-
 	msgDeactivateDeal := &types.MsgDeactivateDeal{
 		DealId:           1,
 		RequesterAddress: suite.buyerAccAddr.String(),
@@ -642,8 +640,6 @@ func (suite dealTestSuite) TestDeactivateDeal() {
 func (suite dealTestSuite) TestDeactivateDealInvalidRequester() {
 	ctx := suite.Ctx
 
-	_ = suite.MakeTestDeal(1, suite.buyerAccAddr)
-
 	msgDeactivateDeal := &types.MsgDeactivateDeal{
 		DealId:           1,
 		RequesterAddress: suite.sellerAccAddr.String(),
@@ -657,11 +653,12 @@ func (suite dealTestSuite) TestDeactivateDealInvalidRequester() {
 func (suite dealTestSuite) TestDeactivateDealStatusNotActive() {
 	ctx := suite.Ctx
 
-	testDeal := suite.MakeTestDeal(1, suite.buyerAccAddr)
+	getDeal, err := suite.DataDealKeeper.GetDeal(ctx, 1)
+	suite.Require().NoError(err)
 
-	testDeal.Status = types.DEAL_STATUS_INACTIVE
+	getDeal.Status = types.DEAL_STATUS_INACTIVE
 
-	err := suite.DataDealKeeper.SetDeal(ctx, testDeal)
+	err = suite.DataDealKeeper.SetDeal(ctx, getDeal)
 	suite.Require().NoError(err)
 
 	msgDeactivateDeal := &types.MsgDeactivateDeal{
@@ -670,5 +667,6 @@ func (suite dealTestSuite) TestDeactivateDealStatusNotActive() {
 	}
 
 	err = suite.DataDealKeeper.DeactivateDeal(ctx, msgDeactivateDeal)
-	suite.Require().ErrorIs(err, types.ErrDealNotActive)
+	suite.Require().ErrorIs(err, types.ErrDealDeactivate)
+	suite.Require().ErrorContains(err, "deal's status is not 'ACTIVE'")
 }

--- a/x/datadeal/keeper/deal_test.go
+++ b/x/datadeal/keeper/deal_test.go
@@ -647,7 +647,7 @@ func (suite dealTestSuite) TestDeactivateDealInvalidRequester() {
 
 	err := suite.DataDealKeeper.DeactivateDeal(ctx, msgDeactivateDeal)
 	suite.Require().ErrorIs(err, types.ErrDealDeactivate)
-	suite.Require().ErrorContains(err, "invalid deactivate requester")
+	suite.Require().ErrorContains(err, "only buyer can deactivate deal")
 }
 
 func (suite dealTestSuite) TestDeactivateDealStatusNotActive() {

--- a/x/datadeal/keeper/deal_test.go
+++ b/x/datadeal/keeper/deal_test.go
@@ -630,6 +630,7 @@ func (suite dealTestSuite) TestDeactivateDeal() {
 	dealAccAddr, err := sdk.AccAddressFromBech32(getDeal.Address)
 	suite.Require().NoError(err)
 
+	// Sending Budget from buyer to deal
 	err = suite.BankKeeper.SendCoins(suite.Ctx, suite.buyerAccAddr, dealAccAddr, sdk.NewCoins(*getDeal.Budget))
 	suite.Require().NoError(err)
 
@@ -637,6 +638,9 @@ func (suite dealTestSuite) TestDeactivateDeal() {
 		DealId:           1,
 		RequesterAddress: suite.buyerAccAddr.String(),
 	}
+
+	beforeDealBalance := suite.BankKeeper.GetBalance(ctx, dealAccAddr, assets.MicroMedDenom)
+	suite.Require().Equal(beforeDealBalance, *getDeal.Budget)
 
 	err = suite.DataDealKeeper.DeactivateDeal(ctx, msgDeactivateDeal)
 	suite.Require().NoError(err)
@@ -648,6 +652,9 @@ func (suite dealTestSuite) TestDeactivateDeal() {
 
 	buyerBalance := suite.BankKeeper.GetBalance(ctx, suite.buyerAccAddr, assets.MicroMedDenom)
 	suite.Require().Equal(buyerBalance, suite.defaultFunds[0])
+
+	afterDealBalance := suite.BankKeeper.GetBalance(ctx, dealAccAddr, assets.MicroMedDenom)
+	suite.Require().Equal(sdk.NewCoin(assets.MicroMedDenom, sdk.NewInt(0)), afterDealBalance)
 
 	//TODO: Check the DataVerification/DeliveryVote Queue are removed well
 }

--- a/x/datadeal/keeper/deal_test.go
+++ b/x/datadeal/keeper/deal_test.go
@@ -636,7 +636,7 @@ func (suite dealTestSuite) TestDeactivateDeal() {
 
 	suite.Require().Equal(getDeal.Status, types.DEAL_STATUS_INACTIVE)
 
-	//TODO: Check the DataVerification/DeliveryVote Queue empty
+	//TODO: Check the DataVerification/DeliveryVote Queue are removed well
 }
 
 func (suite dealTestSuite) TestDeactivateDealInvalidRequester() {

--- a/x/datadeal/keeper/msg_server_deal.go
+++ b/x/datadeal/keeper/msg_server_deal.go
@@ -82,5 +82,12 @@ func (m msgServer) VoteDataDelivery(goCtx context.Context, msg *types.MsgVoteDat
 
 // DeactivateDeal defines a method for deactivating the deal.
 func (m msgServer) DeactivateDeal(goCtx context.Context, msg *types.MsgDeactivateDeal) (*types.MsgDeactivateDealResponse, error) {
-	panic("implements me")
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	err := m.Keeper.DeactivateDeal(ctx, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.MsgDeactivateDealResponse{}, nil
 }

--- a/x/datadeal/types/errors.go
+++ b/x/datadeal/types/errors.go
@@ -17,4 +17,6 @@ var (
 	ErrDataVerificationVote = sdkerrors.Register(ModuleName, 9, "error while voting for DataVerification")
 	ErrDataDeliveryVote     = sdkerrors.Register(ModuleName, 10, "error while voting for DataDelivery")
 	ErrOracleNotActive      = sdkerrors.Register(ModuleName, 11, "oracle is not in 'ACTIVE' state")
+	ErrDealDeactivate       = sdkerrors.Register(ModuleName, 12, "error while deactivating a deal")
+	ErrDealNotActive        = sdkerrors.Register(ModuleName, 13, "deal's status is not 'ACTIVE'")
 )

--- a/x/datadeal/types/errors.go
+++ b/x/datadeal/types/errors.go
@@ -18,5 +18,4 @@ var (
 	ErrDataDeliveryVote     = sdkerrors.Register(ModuleName, 10, "error while voting for DataDelivery")
 	ErrOracleNotActive      = sdkerrors.Register(ModuleName, 11, "oracle is not in 'ACTIVE' state")
 	ErrDealDeactivate       = sdkerrors.Register(ModuleName, 12, "error while deactivating a deal")
-	ErrDealNotActive        = sdkerrors.Register(ModuleName, 13, "deal's status is not 'ACTIVE'")
 )

--- a/x/datadeal/types/message_deal.go
+++ b/x/datadeal/types/message_deal.go
@@ -214,7 +214,7 @@ func (msg *MsgDeactivateDeal) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid requester address (%s)", err)
 	}
 
-	if msg.DealId <= 0 {
+	if msg.DealId == 0 {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid deal id format")
 	}
 	return nil


### PR DESCRIPTION
Closes #420 
- Implement Deactivate Deal keeper, Tx CLI, and test code for keeper function.
- Marked as a `TODO` that when after deactivating a deal, the DataVerification/Delivery vote queue will be removed after #449 merged.