### PR TITLE
feat: add test for reward distribution with delegation

### DIFF
--- a/types/testsuite/suite.go
+++ b/types/testsuite/suite.go
@@ -32,6 +32,7 @@ import (
 	ibctransfertypes "github.com/cosmos/ibc-go/v2/modules/apps/transfer/types"
 	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v2/modules/core/keeper"
+	"github.com/medibloc/panacea-core/v2/types/assets"
 	aolkeeper "github.com/medibloc/panacea-core/v2/x/aol/keeper"
 	aoltypes "github.com/medibloc/panacea-core/v2/x/aol/types"
 	burnkeeper "github.com/medibloc/panacea-core/v2/x/burn/keeper"
@@ -170,6 +171,15 @@ func (suite *TestSuite) SetupTest() {
 	suite.StakingKeeper = stakingkeeper.NewKeeper(
 		cdc.Marshaler, keyParams[stakingtypes.StoreKey], suite.AccountKeeper, suite.BankKeeper, paramsKeeper.Subspace(stakingtypes.ModuleName),
 	)
+	defaultParams := stakingtypes.NewParams(
+		stakingtypes.DefaultUnbondingTime,
+		stakingtypes.DefaultMaxValidators,
+		stakingtypes.DefaultMaxEntries,
+		stakingtypes.DefaultHistoricalEntries,
+		assets.MicroMedDenom,
+		stakingtypes.DefaultMinCommissionRate,
+	)
+	suite.StakingKeeper.SetParams(suite.Ctx, defaultParams)
 	suite.BurnKeeper = *burnkeeper.NewKeeper(suite.BankKeeper)
 	suite.DistrKeeper = distrkeeper.NewKeeper(
 		cdc.Marshaler, keyParams[distrtypes.StoreKey], paramsKeeper.Subspace(distrtypes.ModuleName), suite.AccountKeeper, suite.BankKeeper, &suite.StakingKeeper, "test_fee_collector", modAccAddrs,

--- a/x/datadeal/keeper/reward_test.go
+++ b/x/datadeal/keeper/reward_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"encoding/base64"
+	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -9,6 +10,7 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/medibloc/panacea-core/v2/types/assets"
 	"github.com/medibloc/panacea-core/v2/x/datadeal/testutil"
 	"github.com/medibloc/panacea-core/v2/x/datadeal/types"
@@ -27,6 +29,8 @@ type rewardTestSuite struct {
 
 	buyerAccAddr sdk.AccAddress
 
+	delegatorAccAddr sdk.AccAddress
+
 	oracleAcc1PrivKey cryptotypes.PrivKey
 	oracleAcc1PubKey  cryptotypes.PubKey
 	oracleAcc1Addr    sdk.AccAddress
@@ -34,6 +38,10 @@ type rewardTestSuite struct {
 	oracleAcc2PrivKey cryptotypes.PrivKey
 	oracleAcc2PubKey  cryptotypes.PubKey
 	oracleAcc2Addr    sdk.AccAddress
+
+	oracleAcc3PrivKey cryptotypes.PrivKey
+	oracleAcc3PubKey  cryptotypes.PubKey
+	oracleAcc3Addr    sdk.AccAddress
 
 	oraclePrivKey *btcec.PrivateKey
 	oraclePubKey  *btcec.PublicKey
@@ -54,6 +62,8 @@ func (suite *rewardTestSuite) BeforeTest(_, _ string) {
 
 	suite.buyerAccAddr = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
 
+	suite.delegatorAccAddr = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+
 	suite.oracleAcc1PrivKey = secp256k1.GenPrivKey()
 	suite.oracleAcc1PubKey = suite.oracleAcc1PrivKey.PubKey()
 	suite.oracleAcc1Addr = sdk.AccAddress(suite.oracleAcc1PubKey.Address())
@@ -61,6 +71,10 @@ func (suite *rewardTestSuite) BeforeTest(_, _ string) {
 	suite.oracleAcc2PrivKey = secp256k1.GenPrivKey()
 	suite.oracleAcc2PubKey = suite.oracleAcc2PrivKey.PubKey()
 	suite.oracleAcc2Addr = sdk.AccAddress(suite.oracleAcc2PubKey.Address())
+
+	suite.oracleAcc3PrivKey = secp256k1.GenPrivKey()
+	suite.oracleAcc3PubKey = suite.oracleAcc3PrivKey.PubKey()
+	suite.oracleAcc3Addr = sdk.AccAddress(suite.oracleAcc3PubKey.Address())
 
 	suite.oraclePrivKey, _ = btcec.NewPrivateKey(btcec.S256())
 	suite.oraclePubKey = suite.oraclePrivKey.PubKey()
@@ -174,4 +188,160 @@ func (suite *rewardTestSuite) TestRewardDistribution() {
 
 	suite.Require().Equal(sdk.NewDecCoins(sdk.NewDecCoin(assets.MicroMedDenom, sdk.NewInt(15_000_000))), suite.DistrKeeper.GetValidatorAccumulatedCommission(ctx, val2.GetOperator()).Commission)
 	suite.Require().Equal(sdk.NewDecCoins(sdk.NewDecCoin(assets.MicroMedDenom, sdk.NewInt(15_000_000))), suite.DistrKeeper.GetValidatorCurrentRewards(ctx, val2.GetOperator()).Rewards)
+}
+
+// Assumes that 3 oracles(validators)
+//
+// oracle commission : 10%
+//
+// ****** oracle1 ******
+// voting power : 10
+// validator commission rate : 10%
+//
+// ****** oracle2 ******
+// voting power : 20
+// validator commission rate : 50%
+//
+// ****** oracle3 ******
+// voting power : 20
+// validator commission rate : 20%
+// self-delegated voting power : 10
+// delegated voting power : 10
+func (suite *rewardTestSuite) TestRewardDistributionWithDelegators() {
+	ctx := suite.Ctx
+
+	err := suite.FundAccount(ctx, suite.buyerAccAddr, suite.defaultFunds)
+	suite.Require().NoError(err)
+
+	err = suite.FundAccount(ctx, suite.delegatorAccAddr, suite.defaultFunds)
+	suite.Require().NoError(err)
+
+	err = suite.FundAccount(ctx, suite.oracleAcc1Addr, suite.defaultFunds)
+	suite.Require().NoError(err)
+
+	err = suite.FundAccount(ctx, suite.oracleAcc2Addr, suite.defaultFunds)
+	suite.Require().NoError(err)
+
+	err = suite.FundAccount(ctx, suite.oracleAcc3Addr, suite.defaultFunds)
+	suite.Require().NoError(err)
+
+	// set validators
+	val1VotingPower := sdk.NewInt(10)
+	val2VotingPower := sdk.NewInt(20)
+	val3VotingPower := sdk.NewInt(10)
+
+	val1Commission := sdk.NewDecWithPrec(1, 1)
+	val2Commission := sdk.NewDecWithPrec(5, 1)
+	val3Commission := sdk.NewDecWithPrec(2, 1)
+	val1 := suite.SetValidator(suite.oracleAcc1PubKey, val1VotingPower, val1Commission)
+	val2 := suite.SetValidator(suite.oracleAcc2PubKey, val2VotingPower, val2Commission)
+	val3 := suite.SetValidator(suite.oracleAcc3PubKey, val3VotingPower, val3Commission)
+
+	// delegation
+	//_, err = suite.StakingKeeper.Delegate(ctx, suite.oracleAcc3Addr, sdk.NewInt(10), stakingtypes.Unbonded, val3, true)
+	//suite.Require().NoError(err)
+	_, err = suite.StakingKeeper.Delegate(ctx, suite.delegatorAccAddr, sdk.NewInt(10), stakingtypes.Unbonded, val3, true)
+	suite.Require().NoError(err)
+
+	suite.SetupValidatorRewards(val1.GetOperator())
+	suite.SetupValidatorRewards(val2.GetOperator())
+	suite.SetupValidatorRewards(val3.GetOperator())
+	suite.DistrKeeper.SetDelegatorStartingInfo(ctx, val3.GetOperator(), suite.delegatorAccAddr, distrtypes.NewDelegatorStartingInfo(1, sdk.NewInt(10).ToDec(), 1))
+	//staking.EndBlocker(ctx, suite.StakingKeeper)
+	//
+	//ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+
+	// set deal
+	dealAddr := types.NewDealAddress(1)
+	msgCreateDeal := &types.MsgCreateDeal{
+		DataSchema:   []string{"http://jsonld.com"},
+		Budget:       &sdk.Coin{Denom: assets.MicroMedDenom, Amount: sdk.NewInt(500_000_000)}, // 500 MED,
+		MaxNumData:   1,
+		BuyerAddress: suite.buyerAccAddr.String(),
+	}
+
+	buyer, err := sdk.AccAddressFromBech32(suite.buyerAccAddr.String())
+	suite.Require().NoError(err)
+
+	dealID, err := suite.DataDealKeeper.CreateDeal(ctx, buyer, msgCreateDeal)
+	suite.Require().NoError(err)
+	suite.Require().Equal(uint64(1), dealID)
+
+	// the balance of deal is 500 MED
+	dealBalance := suite.BankKeeper.GetBalance(ctx, dealAddr, assets.MicroMedDenom)
+	suite.Require().Equal(sdk.NewCoin(assets.MicroMedDenom, sdk.NewInt(500_000_000)), dealBalance)
+
+	// oracle lists to be rewarded (3 oracles)
+	oracles := make(map[string]*oracletypes.OracleValidatorInfo)
+	oracles[suite.oracleAcc1Addr.String()] = &oracletypes.OracleValidatorInfo{
+		Address:         suite.oracleAcc1Addr.String(),
+		OracleActivated: true,
+		BondedTokens:    sdk.NewInt(10),
+		ValidatorJailed: false,
+	}
+	oracles[suite.oracleAcc2Addr.String()] = &oracletypes.OracleValidatorInfo{
+		Address:         suite.oracleAcc2Addr.String(),
+		OracleActivated: true,
+		BondedTokens:    sdk.NewInt(20),
+		ValidatorJailed: false,
+	}
+	oracles[suite.oracleAcc3Addr.String()] = &oracletypes.OracleValidatorInfo{
+		Address:         suite.oracleAcc3Addr.String(),
+		OracleActivated: true,
+		BondedTokens:    sdk.NewInt(20),
+		ValidatorJailed: false,
+	}
+
+	// before distribution, the balance of distrModuleAcc is 0 MED
+	distrModuleAcc := suite.AccountKeeper.GetModuleAccount(ctx, distrtypes.ModuleName).GetAddress()
+	distrBalance := suite.BankKeeper.GetBalance(ctx, distrModuleAcc, assets.MicroMedDenom)
+	suite.Require().Equal(sdk.NewCoin(assets.MicroMedDenom, sdk.ZeroInt()), distrBalance)
+
+	// distribute rewards to oracles
+	suite.DataDealKeeper.DistributeRewards(ctx, dealID, oracles)
+
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+
+	// after distribution, the balance of deal is 450 MED. 10%(50 MED) was sent to distrModuleAcc for reward
+	dealBalance = suite.BankKeeper.GetBalance(ctx, dealAddr, assets.MicroMedDenom)
+	suite.Require().Equal(sdk.NewCoin(assets.MicroMedDenom, sdk.NewInt(450_000_000)), dealBalance)
+
+	// the balance of distrModuleAcc is 50 MED, which is 10% of 500 MED
+	distrBalance = suite.BankKeeper.GetBalance(ctx, distrModuleAcc, assets.MicroMedDenom)
+	suite.Require().Equal(sdk.NewCoin(assets.MicroMedDenom, sdk.NewInt(50_000_000)), distrBalance)
+
+	// Among total oracle commission(50 MED),
+	// 10 MED (20% of 50 MED) for oracle 1
+	// - 1 MED (validator commission) + 9 MED (validator reward)
+	//
+	// 20 MED (40% of 50 MED) for oracle 2
+	// - 10 MED (validator commission) + 10 MED (validator reward)
+	//
+	// 20 MED (40% of 50 MED) for oracle 3
+	// - 4 MED (validator commission) + 8 MED (validator reward) + 8 MED (delegator reward)
+
+	suite.Require().Equal(sdk.NewDecCoins(sdk.NewDecCoin(assets.MicroMedDenom, sdk.NewInt(1_000_000))), suite.DistrKeeper.GetValidatorAccumulatedCommission(ctx, val1.GetOperator()).Commission)
+	suite.Require().Equal(sdk.NewDecCoins(sdk.NewDecCoin(assets.MicroMedDenom, sdk.NewInt(9_000_000))), suite.DistrKeeper.GetValidatorCurrentRewards(ctx, val1.GetOperator()).Rewards)
+
+	suite.Require().Equal(sdk.NewDecCoins(sdk.NewDecCoin(assets.MicroMedDenom, sdk.NewInt(10_000_000))), suite.DistrKeeper.GetValidatorAccumulatedCommission(ctx, val2.GetOperator()).Commission)
+	suite.Require().Equal(sdk.NewDecCoins(sdk.NewDecCoin(assets.MicroMedDenom, sdk.NewInt(10_000_000))), suite.DistrKeeper.GetValidatorCurrentRewards(ctx, val2.GetOperator()).Rewards)
+
+	suite.Require().Equal(sdk.NewDecCoins(sdk.NewDecCoin(assets.MicroMedDenom, sdk.NewInt(4_000_000))), suite.DistrKeeper.GetValidatorAccumulatedCommission(ctx, val3.GetOperator()).Commission)
+	suite.Require().Equal(sdk.NewDecCoins(sdk.NewDecCoin(assets.MicroMedDenom, sdk.NewInt(16_000_000))), suite.DistrKeeper.GetValidatorCurrentRewards(ctx, val3.GetOperator()).Rewards)
+
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+	del := suite.StakingKeeper.Delegation(ctx, suite.delegatorAccAddr, val3.GetOperator())
+	selfDel := suite.StakingKeeper.Delegation(ctx, suite.oracleAcc3Addr, val3.GetOperator())
+
+	val3 = suite.StakingKeeper.Validator(ctx, val3.GetOperator()).(stakingtypes.Validator)
+	endingPeriod := suite.DistrKeeper.IncrementValidatorPeriod(ctx, val3)
+	delegatorReward := suite.DistrKeeper.CalculateDelegationRewards(ctx, val3, del, endingPeriod)
+	//validatorReward := suite.DistrKeeper.CalculateDelegationRewards(ctx, val3, selfDel, endingPeriod)
+
+	fmt.Println(selfDel.GetShares())
+
+	//dels, err := suite.DistrKeeper.DelegatorValidators(sdk.WrapSDKContext(ctx), &distrtypes.QueryDelegatorValidatorsRequest{DelegatorAddress: suite.oracleAcc3Addr.String()})
+
+	suite.Require().Equal(sdk.NewDecCoins(sdk.NewDecCoin(assets.MicroMedDenom, sdk.NewInt(8_000_000))), delegatorReward)
+	//suite.Require().Equal(sdk.NewDecCoins(sdk.NewDecCoin(assets.MicroMedDenom, sdk.NewInt(8_000_000))), validatorReward)
 }

--- a/x/datadeal/testutil/suite.go
+++ b/x/datadeal/testutil/suite.go
@@ -51,17 +51,13 @@ func (suite *DataDealBaseTestSuite) SetValidator(pubKey cryptotypes.PubKey, amou
 	validator, err := stakingtypes.NewValidator(varAddr, pubKey, stakingtypes.Description{})
 	suite.Require().NoError(err)
 	validator = validator.UpdateStatus(stakingtypes.Bonded)
-	//validator, _ = validator.AddTokensFromDel(amount)
+	validator, _ = validator.AddTokensFromDel(amount)
 	newCommission := stakingtypes.NewCommission(commission, sdk.OneDec(), sdk.NewDecWithPrec(5, 1))
 	validator.Commission = newCommission
 	validator.MinSelfDelegation = amount
 
 	suite.StakingKeeper.SetValidator(suite.Ctx, validator)
 	err = suite.StakingKeeper.SetValidatorByConsAddr(suite.Ctx, validator)
-	suite.Require().NoError(err)
-
-	accAddr := sdk.AccAddress(pubKey.Address().Bytes())
-	_, err = suite.StakingKeeper.Delegate(suite.Ctx, accAddr, amount, stakingtypes.Unbonded, validator, true)
 	suite.Require().NoError(err)
 
 	return validator

--- a/x/datadeal/testutil/suite.go
+++ b/x/datadeal/testutil/suite.go
@@ -5,6 +5,7 @@ import (
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/medibloc/panacea-core/v2/types/assets"
 	"github.com/medibloc/panacea-core/v2/types/testsuite"
@@ -50,12 +51,17 @@ func (suite *DataDealBaseTestSuite) SetValidator(pubKey cryptotypes.PubKey, amou
 	validator, err := stakingtypes.NewValidator(varAddr, pubKey, stakingtypes.Description{})
 	suite.Require().NoError(err)
 	validator = validator.UpdateStatus(stakingtypes.Bonded)
-	validator, _ = validator.AddTokensFromDel(amount)
+	//validator, _ = validator.AddTokensFromDel(amount)
 	newCommission := stakingtypes.NewCommission(commission, sdk.OneDec(), sdk.NewDecWithPrec(5, 1))
 	validator.Commission = newCommission
+	validator.MinSelfDelegation = amount
 
 	suite.StakingKeeper.SetValidator(suite.Ctx, validator)
 	err = suite.StakingKeeper.SetValidatorByConsAddr(suite.Ctx, validator)
+	suite.Require().NoError(err)
+
+	accAddr := sdk.AccAddress(pubKey.Address().Bytes())
+	_, err = suite.StakingKeeper.Delegate(suite.Ctx, accAddr, amount, stakingtypes.Unbonded, validator, true)
 	suite.Require().NoError(err)
 
 	return validator
@@ -118,4 +124,13 @@ func (suite *DataDealBaseTestSuite) SetAccount(pubKey cryptotypes.PubKey) {
 	oracleAccount := suite.AccountKeeper.NewAccountWithAddress(suite.Ctx, oracleAccAddr)
 	suite.Require().NoError(oracleAccount.SetPubKey(pubKey))
 	suite.AccountKeeper.SetAccount(suite.Ctx, oracleAccount)
+}
+
+func (suite *DataDealBaseTestSuite) SetupValidatorRewards(valAddress sdk.ValAddress) {
+	decCoins := sdk.DecCoins{sdk.NewDecCoinFromDec(assets.MicroMedDenom, sdk.ZeroDec())}
+	historicalRewards := distrtypes.NewValidatorHistoricalRewards(decCoins, 1)
+	suite.DistrKeeper.SetValidatorHistoricalRewards(suite.Ctx, valAddress, 1, historicalRewards)
+	// setup current rewards
+	currentRewards := distrtypes.NewValidatorCurrentRewards(decCoins, 2)
+	suite.DistrKeeper.SetValidatorCurrentRewards(suite.Ctx, valAddress, currentRewards)
 }


### PR DESCRIPTION
Close #451 

Add test case for reward distribution with delegator

### Assumed environment

price per data : 500 MED
oracle commission : 10%

****** oracle1 ******
voting power : 10
validator commission rate : 10%

****** oracle2 ******
voting power : 20
validator commission rate : 50%

****** oracle3 ******
voting power : 20 (10 for self-delegation + 10 for delegation)
validator commission rate : 20%

### Expected Result

- total voting power : 50
- total oracle commission : 50 MED (10% of 500 MED)
- oracle 1 commission : 10 MED (50 MED * 10/50)
  - commission : 1 MED
  - reward : 9 MED

- oracle 2 commission : 20 MED (50 MED * 20/50)
  - commission : 10 MED
  - reward : 10 MED

- oracle 3 commission : 20 MED (50 MED * 20/50) 
  - commission : 4 MED (20% of 20 MED)
  - validator reward : 8 MED (16 MED * 10/20)
  - delegator reward : 8 MED (16 MED * 10/20)