### PR TITLE
feat: add function that remove DataVerification/DeliveryVote Queue

### DIFF
--- a/x/datadeal/keeper/keeper.go
+++ b/x/datadeal/keeper/keeper.go
@@ -53,7 +53,7 @@ func (k Keeper) GetOracleKeeper() oraclekeeper.Keeper {
 
 func (k Keeper) AddDataVerificationQueue(ctx sdk.Context, dataHash string, dealID uint64, endTime time.Time) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.GetDataVerificationQueueKey(dataHash, dealID, endTime), []byte(dataHash))
+	store.Set(types.GetDataVerificationQueueKey(dealID, dataHash, endTime), []byte(dataHash))
 }
 
 func (k Keeper) GetAllDataVerificationQueueElements(ctx sdk.Context) ([]types.DataVerificationQueueElement, error) {
@@ -88,7 +88,7 @@ func (k Keeper) GetClosedDataVerificationQueueIterator(ctx sdk.Context, endTime 
 
 func (k Keeper) RemoveDataVerificationQueue(ctx sdk.Context, dealID uint64, dataHash string, endTime time.Time) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.GetDataVerificationQueueKey(dataHash, dealID, endTime))
+	store.Delete(types.GetDataVerificationQueueKey(dealID, dataHash, endTime))
 }
 
 func (k Keeper) IterateClosedDataVerificationQueue(ctx sdk.Context, endTime time.Time, cb func(dataSale *types.DataSale) (stop bool)) {

--- a/x/datadeal/types/keys.go
+++ b/x/datadeal/types/keys.go
@@ -49,7 +49,7 @@ func GetDealKey(dealID uint64) []byte {
 	return append(KeyPrefixDeals, sdk.Uint64ToBigEndian(dealID)...)
 }
 
-func GetDataSaleKey(dataHash string, dealID uint64) []byte {
+func GetDataSaleKey(dealID uint64, dataHash string) []byte {
 	return append(DataSaleKey, CombineKeys(sdk.Uint64ToBigEndian(dealID), []byte(dataHash))...)
 }
 
@@ -57,15 +57,15 @@ func GetDataSalesKey(dealID uint64) []byte {
 	return append(DataSaleKey, sdk.Uint64ToBigEndian(dealID)...)
 }
 
-func GetDataVerificationVoteKey(dataHash string, voterAddress sdk.AccAddress, dealID uint64) []byte {
+func GetDataVerificationVoteKey(dealID uint64, dataHash string, voterAddress sdk.AccAddress) []byte {
 	return append(DataVerificationVoteKey, CombineKeys(sdk.Uint64ToBigEndian(dealID), []byte(dataHash), voterAddress)...)
 }
 
-func GetDataVerificationVotesKey(dataHash string, dealID uint64) []byte {
+func GetDataVerificationVotesKey(dealID uint64, dataHash string) []byte {
 	return append(DataVerificationVoteKey, CombineKeys(sdk.Uint64ToBigEndian(dealID), []byte(dataHash))...)
 }
 
-func GetDataVerificationQueueKey(dataHash string, dealID uint64, endTime time.Time) []byte {
+func GetDataVerificationQueueKey(dealID uint64, dataHash string, endTime time.Time) []byte {
 	return append(DataVerificationQueueKey, CombineKeys(sdk.FormatTimeBytes(endTime), sdk.Uint64ToBigEndian(dealID), []byte(dataHash))...)
 }
 

--- a/x/datadeal/types/keys_test.go
+++ b/x/datadeal/types/keys_test.go
@@ -13,7 +13,7 @@ func TestSplitDataVerificationVoteQueueKey(t *testing.T) {
 	dataHash := "dataHash"
 	now := time.Now()
 
-	key := types.GetDataVerificationQueueKey(dataHash, dealID, now)
+	key := types.GetDataVerificationQueueKey(dealID, dataHash, now)
 
 	_, splitDealID, splitCID, err := types.SplitDataQueueKey(key)
 	require.NoError(t, err)


### PR DESCRIPTION
Add `RemoveVotingQueue` function that remove all DataVerification/DeliveryVote Queue related deactivating deal.

Minor changes:
- The order of key parameters is uniformly matched.