### PR TITLE
fix: add base64 encoding in data encryption

### DIFF
--- a/cmd/panacead/cmd/encrypt_data.go
+++ b/cmd/panacead/cmd/encrypt_data.go
@@ -51,7 +51,9 @@ func EncryptDataCmd(defaultNodeHome string) *cobra.Command {
 				return err
 			}
 
-			if err := os.WriteFile(args[1], encryptedData, 0644); err != nil {
+			encryptedDataBase64 := []byte(base64.StdEncoding.EncodeToString(encryptedData))
+
+			if err := os.WriteFile(args[1], encryptedDataBase64, 0644); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
`encrypt-data` CLI returns encrypted data encoded using base64, which can be used to request for data validation.