### PR TITLE
fix: change signer to provider address in sumbit consent msg

### DIFF
--- a/x/datadeal/types/message_deal.go
+++ b/x/datadeal/types/message_deal.go
@@ -80,7 +80,7 @@ func (m *MsgSubmitConsent) GetSignBytes() []byte {
 }
 
 func (m *MsgSubmitConsent) GetSigners() []sdk.AccAddress {
-	oracleAddress, err := sdk.AccAddressFromBech32(m.Certificate.UnsignedCertificate.OracleAddress)
+	oracleAddress, err := sdk.AccAddressFromBech32(m.Certificate.UnsignedCertificate.ProviderAddress)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR is based on #548.

Changed the signer of `MsgSubmitConsent` from `OracleAddress` to `ProviderAddress`