### PR TITLE
fix: Change byte array to string when decypt-data cli output logs

### DIFF
--- a/cmd/panacead/cmd/decrypt_data.go
+++ b/cmd/panacead/cmd/decrypt_data.go
@@ -58,7 +58,7 @@ func DecryptDataCmd(defaultNodeHome string) *cobra.Command {
 				return err
 			}
 
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), decryptedData)
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), string(decryptedData))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
related: #554 

When outputting the `decrypt-data` cmd we need to change the type byte array to string.