### PR TITLE
docs: Update Docker image version from 'latest' to 'main'

### DIFF
--- a/.gitbook/5-oracles/1-operate-oracle-nodes/2-oracle-intialization.md
+++ b/.gitbook/5-oracles/1-operate-oracle-nodes/2-oracle-intialization.md
@@ -17,7 +17,7 @@ mkdir <directory-you-want>/oracle
 export ORACLE_CMD="docker run --rm \
   --device /dev/sgx_enclave \
   --device /dev/sgx_provision \
-  -v <directory-you-want>/oracle:/oracle ghcr.io/medibloc/panacea-oracle:latest \
+  -v <directory-you-want>/oracle:/oracle ghcr.io/medibloc/panacea-oracle:main \
   ego run /usr/bin/oracled"
 ```
 

--- a/.gitbook/5-oracles/1-operate-oracle-nodes/3-genesis-oracle.md
+++ b/.gitbook/5-oracles/1-operate-oracle-nodes/3-genesis-oracle.md
@@ -31,7 +31,7 @@ Execute the command in oracle as follows:
 docker run \
     --device /dev/sgx_enclave \
     --device /dev/sgx_provision \
-    ghcr.io/medibloc/panacea-oracle:latest \
+    ghcr.io/medibloc/panacea-oracle:main \
     ego uniqueid /usr/bin/oracled
 ```
 **Output**
@@ -117,7 +117,7 @@ docker run \
     --device /dev/sgx_enclave \
     --device /dev/sgx_provision \
     -v <directory-you-want>:/oracle \
-    ghcr.io/medibloc/panacea-oracle:latest \
+    ghcr.io/medibloc/panacea-oracle:main \
     ego run /usr/bin/oracled gen-oracle-key \
       --trusted-block-height $HEIGHT \
       --trusted-block-hash $HASH

--- a/.gitbook/5-oracles/1-operate-oracle-nodes/4-oracle-registration.md
+++ b/.gitbook/5-oracles/1-operate-oracle-nodes/4-oracle-registration.md
@@ -34,7 +34,7 @@ docker run \
     --device /dev/sgx_enclave \
     --device /dev/sgx_provision \
     -v <directory-you-want>/oracle:/oracle \
-    ghcr.io/medibloc/panacea-oracle:latest \
+    ghcr.io/medibloc/panacea-oracle:main \
     ego run /usr/bin/oracled register-oracle \ 
     --trusted-block-height ${HEIGHT} \
     --trusted-block-hash ${HASH} \
@@ -97,7 +97,7 @@ docker run \
     --device /dev/sgx_enclave \
     --device /dev/sgx_provision \
     -v ${ANY_DIR_ON_HOST}:/oracle \
-    ghcr.io/medibloc/panacea-oracle:latest \
+    ghcr.io/medibloc/panacea-oracle:main \
     ego run /usr/bin/oracled get-oracle-key
 ```
 

--- a/.gitbook/5-oracles/1-operate-oracle-nodes/5-running-oracle-node.md
+++ b/.gitbook/5-oracles/1-operate-oracle-nodes/5-running-oracle-node.md
@@ -26,7 +26,7 @@ docker run \
     --device /dev/sgx_enclave \
     --device /dev/sgx_provision \
     -v ${ANY_DIR_ON_HOST}:/oracle \
-    ghcr.io/medibloc/panacea-oracle:latest \
+    ghcr.io/medibloc/panacea-oracle:main \
     ego run /usr/bin/oracled start
 ```
 If the oracle is successfully started, you will see the following log message:

--- a/.gitbook/5-oracles/1-operate-oracle-nodes/6-update-oracle-info.md
+++ b/.gitbook/5-oracles/1-operate-oracle-nodes/6-update-oracle-info.md
@@ -11,7 +11,7 @@ docker run \
     --device /dev/sgx_enclave \
     --device /dev/sgx_provision \
     -v <directory-you-want>/oracle:/oracle \
-    ghcr.io/medibloc/panacea-oracle:latest \
+    ghcr.io/medibloc/panacea-oracle:main \
     ego run /usr/bin/oracled update-oracle-info \ 
     --oracle-endpoint "<your-new-endpoint>" \ 
     --oracle-commission-rate <your-new-commission-rate>

--- a/.gitbook/5-oracles/1-operate-oracle-nodes/7-oracle-upgrade.md
+++ b/.gitbook/5-oracles/1-operate-oracle-nodes/7-oracle-upgrade.md
@@ -59,7 +59,7 @@ Let's start with [initialization](2-oracle-intialization.md) of the new version 
 export ORACLE_CMD="docker run --rm \
   --device /dev/sgx_enclave \
   --device /dev/sgx_provision \
-  -v <directory-you-want>/oracle:/oracle ghcr.io/medibloc/panacea-oracle:latest \
+  -v <directory-you-want>/oracle:/oracle ghcr.io/medibloc/panacea-oracle:main \
   ego run /usr/bin/oracled"
   
   $ORACLE_CMD init --home /home_mnt/.oracle-new


### PR DESCRIPTION
Update the Docker image version in the documentation to reflect the actual available version. The 'latest' tag was not available, causing confusion for users. The 'main' tag should be used instead.