### PR TITLE
docs: add install guide and releases link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ Panacea is a blockchain which is the key infrastructure for our services to rein
 ## License
 
 [Apache-2.0 License](LICENSE)
+
+## Install Guide
+- See detailed instructions: https://docs.gopanacea.org
+- For releases: https://github.com/medibloc/panacea-core/releases


### PR DESCRIPTION
Adds links to docs.gopanacea.org and GitHub Releases for setup clarity. No code changes.